### PR TITLE
Support file paths that contains spaces

### DIFF
--- a/src/Markdownify.ts
+++ b/src/Markdownify.ts
@@ -29,7 +29,7 @@ export class Markdownify {
     }
 
     const { stdout, stderr } = await execAsync(
-      `${uvPath} run ${markitdownPath} ${filePath}`,
+      `${uvPath} run ${markitdownPath} "${filePath}"`,
     );
 
     if (stderr) {


### PR DESCRIPTION
Currently, if I run this mcp against a file that contains spaces in their name, or located in a folder that contains spaces, it will error. This PR simply adds "" around the file path to support paths containing spaces.