### PR TITLE
fix windows platform preinstall & executable file path

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "build": "tsc && shx chmod +x dist/*.js",
     "prepare": "npm run build",
     "dev": "tsc --watch",
-    "preinstall": "./setup.sh",
+    "preinstall": "node preinstall.js",
     "start": "node dist/index.js",
     "test": "bun test",
     "test:watch": "bun test --watch"

--- a/preinstall.js
+++ b/preinstall.js
@@ -1,0 +1,7 @@
+import { execSync } from 'child_process';
+
+if (process.platform === 'win32') {
+  execSync('setup.bat', { stdio: 'inherit' });
+} else {
+  execSync('./setup.sh', { stdio: 'inherit' });
+}

--- a/setup.bat
+++ b/setup.bat
@@ -1,0 +1,7 @@
+echo 'prepare Windows preinstall'
+echo 'Installing Python dependencies for OCR...'
+echo 'Installing uv'
+powershell -ExecutionPolicy ByPass -c "irm https://astral.sh/uv/install.ps1 | iex"
+echo 'Using uv to install markitdown'
+uv sync
+echo 'Finished install Python dependencies'

--- a/setup.sh
+++ b/setup.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+echo 'prepare Unix preinstall'
 echo 'Installing Python dependencies for OCR...'
 echo 'Installing uv'
 curl -LsSf https://astral.sh/uv/install.sh | sh

--- a/src/Markdownify.ts
+++ b/src/Markdownify.ts
@@ -22,7 +22,11 @@ export class Markdownify {
     uvPath: string,
   ): Promise<string> {
     const venvPath = path.join(projectRoot, ".venv");
-    const markitdownPath = path.join(venvPath, "bin", "markitdown");
+    const markitdownPath = path.join(
+      venvPath, 
+      process.platform === 'win32' ? 'Scripts' : 'bin', 
+      `markitdown${process.platform === 'win32' ? '.exe' : ''}`
+    );
 
     if (!fs.existsSync(markitdownPath)) {
       throw new Error("markitdown executable not found");


### PR DESCRIPTION
Hope this pr could fix windows platform fail mentioned in #5, I haven't do strict test.

Additionally, I found another problem. if I don't miss anything, currently this mcp must start from project's root path or it could throw error ``ModuleNotFoundError: No module named 'markitdown'`` , but unfortunately some system(ex. I'm using  Cherry Studio) seems could start mcp server not in project's root path, how do solve this?