### PR TITLE
Added get-markdown-file validations 

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,8 @@ To integrate this server with a desktop app, add the following to your app's ser
 - `xlsx-to-markdown`: Convert XLSX files to Markdown
 - `pptx-to-markdown`: Convert PPTX files to Markdown
 - `get-markdown-file`: Retrieve an existing Markdown file. File extension must end with: *.md, *.markdown.
+  
+  OPTIONAL: set `MD_SHARE_DIR` env var to restrict the directory from which files can be retrieved, e.g. `MD_SHARE_DIR=[SOME_PATH] pnpm run start` 
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ To integrate this server with a desktop app, add the following to your app's ser
 - `docx-to-markdown`: Convert DOCX files to Markdown
 - `xlsx-to-markdown`: Convert XLSX files to Markdown
 - `pptx-to-markdown`: Convert PPTX files to Markdown
-- `get-markdown-file`: Retrieve an existing Markdown file
+- `get-markdown-file`: Retrieve an existing Markdown file. File extension must end with: *.md, *.markdown.
 
 ## Contributing
 

--- a/src/Markdownify.ts
+++ b/src/Markdownify.ts
@@ -114,6 +114,13 @@ export class Markdownify {
       throw new Error("Required file is not a Markdown file.");
     }
 
+    if (process.env?.MD_SHARE_DIR) {
+      const allowedShareDir = this.normalizePath(path.resolve(this.expandHome(process.env.MD_SHARE_DIR)));
+      if (!normPath.startsWith(allowedShareDir)) {
+        throw new Error(`Only files in ${allowedShareDir} are allowed.`);
+      }
+    }
+
     if (!fs.existsSync(filePath)) {
       throw new Error("File does not exist");
     }

--- a/src/Markdownify.ts
+++ b/src/Markdownify.ts
@@ -48,6 +48,17 @@ export class Markdownify {
     return tempOutputPath;
   }
 
+  private static normalizePath(p: string): string {
+    return path.normalize(p);
+  }
+  
+  private static expandHome(filepath: string): string {
+    if (filepath.startsWith('~/') || filepath === '~') {
+      return path.join(os.homedir(), filepath.slice(1));
+    }
+    return filepath;
+  }
+
   static async toMarkdown({
     filePath,
     url,
@@ -96,6 +107,13 @@ export class Markdownify {
   }: {
     filePath: string;
   }): Promise<MarkdownResult> {
+    // Check file type is *.md or *.markdown
+    const normPath = this.normalizePath(path.resolve(this.expandHome(filePath)));
+    const markdownExt = [".md", ".markdown"];
+    if (!markdownExt.includes(path.extname(normPath))){
+      throw new Error("Required file is not a Markdown file.");
+    }
+
     if (!fs.existsSync(filePath)) {
       throw new Error("File does not exist");
     }


### PR DESCRIPTION
Two checks were added to the `get-markdown-file` tool:

1. Check that `filePath` ends with `*.md` or `*.markdown`.
2. If `MD_SHARE_DIR` env var is set by the user, check that `filePath` is within that directory.

These checks are meant to mitigate arbitrary file read issues.