### PR TITLE
setup: bugfix: source uv after install

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -4,6 +4,7 @@ echo 'prepare Unix preinstall'
 echo 'Installing Python dependencies for OCR...'
 echo 'Installing uv'
 curl -LsSf https://astral.sh/uv/install.sh | sh
+source $HOME/.local/bin/env
 echo 'Using uv to install markitdown'
 uv sync
 echo 'Finished install Python dependencies'


### PR DESCRIPTION
The uv install script asks you to source the env file it creates in .local/bin after finishing. Without doing this, uv sync may fail in some environments (for example, it fails in a docker container).

Source the env file between installation and the uv sync call.