### PR TITLE
bugfix: allow webpage function to handle PDFs

### DIFF
--- a/src/Markdownify.ts
+++ b/src/Markdownify.ts
@@ -43,10 +43,15 @@ export class Markdownify {
     return stdout;
   }
 
-  private static async saveToTempFile(content: string): Promise<string> {
+  private static async saveToTempFile(content: string | Buffer, suggestedExtension?: string | null): Promise<string> {
+    let outputExtension = "md";
+    if (suggestedExtension != null) {
+      outputExtension = suggestedExtension;
+    }
+
     const tempOutputPath = path.join(
       os.tmpdir(),
-      `markdown_output_${Date.now()}.md`,
+      `markdown_output_${Date.now()}.${outputExtension}`,
     );
     fs.writeFileSync(tempOutputPath, content);
     return tempOutputPath;
@@ -80,8 +85,17 @@ export class Markdownify {
 
       if (url) {
         const response = await fetch(url);
-        const content = await response.text();
-        inputPath = await this.saveToTempFile(content);
+
+        let extension = null;
+
+        if (url.endsWith(".pdf")) {
+          extension = "pdf";
+        }
+
+        const arrayBuffer = await response.arrayBuffer();
+        const content = Buffer.from(arrayBuffer);
+
+        inputPath = await this.saveToTempFile(content, extension);
         isTemporary = true;
       } else if (filePath) {
         inputPath = filePath;


### PR DESCRIPTION
Two reasons why this wasn't working:

1. we were always downloading a 'webpage' as text, rather than raw bytes, before writing it out to a temp file, causing some encoding issue where extra bytes were being inserted into the downloaded PDF, corrupting it.
2. the markitdown tool clearly changes functionality based on the extension of the input file - passing it a temporary input file ending with .md made it not convert the PDF. Note this isn't the only case where this is happening, which should probably be looked into.

Intended to fix https://github.com/zcaceres/markdownify-mcp/issues/21