### PR TITLE
Add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,40 @@
+# Base stage will contain python dependencies
+FROM node:current-alpine3.22 AS base
+WORKDIR /app
+
+# Install dependencies
+RUN apk add --no-cache python3 curl bash
+
+# Copy the source code
+COPY . .
+# Remove the python version, otherwise it won't find python
+RUN rm .python-version
+
+# Enable pnpm
+RUN corepack enable
+
+# Install Python dependencies
+RUN ./setup.sh
+
+# Use a separate stage for building to save space
+FROM base AS builder
+
+# Install Node.js dependencies
+RUN pnpm install
+
+# Build the project
+RUN pnpm run build
+
+# Set the entry point
+ENTRYPOINT ["node", "dist/index.js"]
+
+# Final stage for the image (doing the build separately saves about 100MB)
+FROM base AS runner
+
+# Install production Node.js dependencies
+RUN pnpm install --production
+
+# Copy the built application
+COPY --from=builder /app/dist ./dist
+
+ENTRYPOINT ["node", "dist/index.js"]

--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
   ],
   "scripts": {
     "build": "tsc && shx chmod +x dist/*.js",
-    "prepare": "npm run build",
     "dev": "tsc --watch",
     "preinstall": "node preinstall.js",
     "start": "node dist/index.js",


### PR DESCRIPTION
Adding this to Docker's MCP registry and we need a Dockerfile!

One thing worth noting is that I removed the `prepare` script, because with it, we'd add another ~100Mb to the final Docker image because it cripples multi-stage builds. I don't think this script is actually necessary though, since users are told to build it first anyway. But maybe the maintainers want it there for a reason?