### PR TITLE
Fix stdout maxBuffer exceeded for large outputs

### DIFF
--- a/src/Markdownify.ts
+++ b/src/Markdownify.ts
@@ -32,9 +32,9 @@ export class Markdownify {
     }
 
     // Use execFile to prevent command injection
-    const { stdout, stderr } = await execFileAsync(markitdownPath, [
-      filePath,
-    ]);
+    const { stdout, stderr } = await execFileAsync(markitdownPath, [filePath], {
+      maxBuffer: 50 * 1024 * 1024, // 50 MB
+    });
 
     if (stderr) {
       throw new Error(`Error executing command: ${stderr}`);


### PR DESCRIPTION
## Summary

- Increase `execFile` maxBuffer from default 1MB to 50MB
- Fixes crashes when converting long YouTube videos or large documents

Fixes #34

## Test plan

- [x] `bun run build` compiles
- [x] `bun test` — all 11 tests pass
- [ ] Convert a long YouTube video (30+ min) without buffer error