### PR TITLE
Detect and reject unconverted HTML output

### DIFF
--- a/src/Markdownify.ts
+++ b/src/Markdownify.ts
@@ -40,6 +40,15 @@ export class Markdownify {
       throw new Error(`Error executing command: ${stderr}`);
     }
 
+    // Detect when markitdown returns unconverted HTML (e.g. JS-rendered SPAs)
+    const trimmed = stdout.trimStart();
+    if (trimmed.startsWith("<!DOCTYPE") || trimmed.startsWith("<html")) {
+      throw new Error(
+        "Conversion failed: the page returned raw HTML that could not be converted to Markdown. " +
+          "This typically happens with JavaScript-rendered pages (SPAs) that require a browser to load content.",
+      );
+    }
+
     return stdout;
   }
 


### PR DESCRIPTION
## Summary

- Detect when markitdown returns raw HTML instead of markdown (e.g. JS-rendered SPAs)
- Return a clear error message instead of a huge HTML blob

Fixes #33

## Test plan

- [x] `bun run build` compiles
- [x] `bun test` — all 11 tests pass
- [ ] `webpage-to-markdown` on a JS-rendered SPA returns a helpful error
- [ ] `webpage-to-markdown` on a static page still converts normally