### PR TITLE
Stop writing converted output to temp files

### DIFF
--- a/src/Markdownify.test.ts
+++ b/src/Markdownify.test.ts
@@ -29,7 +29,6 @@ test("Markdownify.toMarkdown converts PDF file to Markdown", async () => {
   const result = await Markdownify.toMarkdown({ filePath: pdfPath });
 
   expect(result).toBeDefined();
-  expect(result.path).toContain("markdown_output_");
   expect(result.text).toContain("Test PDF content");
 });
 
@@ -38,7 +37,6 @@ test("Markdownify.toMarkdown converts DOCX file to Markdown", async () => {
   const result = await Markdownify.toMarkdown({ filePath: docxPath });
 
   expect(result).toBeDefined();
-  expect(result.path).toContain("markdown_output_");
   expect(result.text).toContain("Test DOCX content");
 });
 
@@ -47,7 +45,6 @@ test("Markdownify.toMarkdown converts XLSX file to Markdown", async () => {
   const result = await Markdownify.toMarkdown({ filePath: xlsxPath });
 
   expect(result).toBeDefined();
-  expect(result.path).toContain("markdown_output_");
   expect(result.text).toContain("Test XLSX content");
 });
 
@@ -56,7 +53,6 @@ test("Markdownify.toMarkdown converts PPTX file to Markdown", async () => {
   const result = await Markdownify.toMarkdown({ filePath: pptxPath });
 
   expect(result).toBeDefined();
-  expect(result.path).toContain("markdown_output_");
   expect(result.text).toContain("Test PPTX content");
 });
 
@@ -65,7 +61,6 @@ test("Markdownify.toMarkdown converts image file to Markdown", async () => {
   const result = await Markdownify.toMarkdown({ filePath: imagePath });
 
   expect(result).toBeDefined();
-  expect(result.path).toContain("markdown_output_");
   // markitdown returns only whitespace for images without LLM vision config
   expect(result.text.trim()).toBe("");
 });
@@ -84,7 +79,6 @@ test("Markdownify.toMarkdown converts URL content to Markdown", async () => {
   const result = await Markdownify.toMarkdown({ url: testUrl });
 
   expect(result).toBeDefined();
-  expect(result.path).toContain("markdown_output_");
   expect(result.text).toContain("# Example Domain");
 });
 

--- a/src/Markdownify.ts
+++ b/src/Markdownify.ts
@@ -11,7 +11,7 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
 export type MarkdownResult = {
-  path: string;
+  path?: string;
   text: string;
 };
 
@@ -110,13 +110,12 @@ export class Markdownify {
       }
 
       const text = await this._markitdown(inputPath, projectRoot);
-      const outputPath = await this.saveToTempFile(text);
 
       if (isTemporary) {
         fs.unlinkSync(inputPath);
       }
 
-      return { path: outputPath, text };
+      return { text };
     } catch (e: unknown) {
       if (e instanceof Error) {
         throw new Error(`Error processing to Markdown: ${e.message}`);

--- a/src/server.ts
+++ b/src/server.ts
@@ -97,8 +97,9 @@ export function createServer() {
 
         return {
           content: [
-            { type: "text", text: `Output file: ${result.path}` },
-            { type: "text", text: `Converted content:` },
+            ...(result.path
+              ? [{ type: "text" as const, text: `Output file: ${result.path}` }]
+              : []),
             { type: "text", text: result.text },
           ],
           isError: false,


### PR DESCRIPTION
## Summary

- Remove unnecessary temp file write for converted markdown output
- The text is already returned inline in the MCP response, making the temp file redundant
- In short-lived Docker containers (e.g. Docker Desktop MCP gateway), the temp path was useless since the container dies immediately
- Input temp files for URL fetches are kept (markitdown CLI needs a file path)

Fixes #38

## Test plan

- [x] `bun run build` compiles
- [x] `bun test` — all 11 tests pass
- [ ] Verify MCP response still contains full converted text
- [ ] Verify no orphaned temp files accumulate in /tmp