### PR TITLE
Fix SSRF via unvalidated HTTP redirects

### DIFF
--- a/src/Markdownify.ts
+++ b/src/Markdownify.ts
@@ -4,6 +4,8 @@ import path from "path";
 import fs from "fs";
 import os from "os";
 import { fileURLToPath } from "url";
+import { URL } from "node:url";
+import is_ip_private from "private-ip";
 import { expandHome } from "./utils.js";
 const execFileAsync = promisify(execFile);
 
@@ -69,6 +71,42 @@ export class Markdownify {
     return tempOutputPath;
   }
 
+  private static validateUrl(url: string): void {
+    const parsed = new URL(url);
+    if (!["http:", "https:"].includes(parsed.protocol)) {
+      throw new Error("Only http: and https: schemes are allowed.");
+    }
+    if (is_ip_private(parsed.hostname)) {
+      throw new Error(
+        `Fetching ${url} is potentially dangerous, aborting.`,
+      );
+    }
+  }
+
+  private static async safeFetch(
+    url: string,
+    maxRedirects = 10,
+  ): Promise<Response> {
+    let currentUrl = url;
+    for (let i = 0; i < maxRedirects; i++) {
+      this.validateUrl(currentUrl);
+      const response = await fetch(currentUrl, { redirect: "manual" });
+      if (
+        response.status >= 300 &&
+        response.status < 400 &&
+        response.headers.get("location")
+      ) {
+        currentUrl = new URL(
+          response.headers.get("location")!,
+          currentUrl,
+        ).toString();
+        continue;
+      }
+      return response;
+    }
+    throw new Error("Too many redirects");
+  }
+
   private static normalizePath(p: string): string {
     return path.normalize(p);
   }
@@ -87,7 +125,7 @@ export class Markdownify {
       let isTemporary = false;
 
       if (url) {
-        const response = await fetch(url);
+        const response = await this.safeFetch(url);
 
         let extension: string | null = null;
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -7,9 +7,6 @@ import {
 import { Markdownify } from "./Markdownify.js";
 import * as tools from "./tools.js";
 import { CallToolRequest } from "@modelcontextprotocol/sdk/types.js";
-import is_ip_private from "private-ip";
-import { URL } from "node:url";
-
 const RequestPayloadSchema = z.object({
   filepath: z.string().optional(),
   url: z.string().optional(),
@@ -50,17 +47,7 @@ export function createServer() {
           case tools.WebpageToMarkdownTool.name:
             if (!validatedArgs.url) {
               throw new Error("URL is required for this tool");
-            }     
-            
-            const parsedUrl = new URL(validatedArgs.url);
-            if (!["http:", "https:"].includes(parsedUrl.protocol)) {
-              throw new Error("Only http: and https: schemes are allowed.");
             }
-            
-            if (is_ip_private(parsedUrl.hostname)) {
-              throw new Error(`Fetching ${validatedArgs.url} is potentially dangerous, aborting.`);
-            }
-    
             result = await Markdownify.toMarkdown({
               url: validatedArgs.url,
               projectRoot: validatedArgs.projectRoot,


### PR DESCRIPTION
## Summary

- Replace `fetch()` with `safeFetch()` that follows redirects manually (up to 10 hops)
- Validate protocol and private IP at each redirect hop, not just the initial URL
- Move URL validation from `server.ts` into `Markdownify.ts` so it can't be bypassed

Fixes GHSA-576m-mhc7-fgw7, fixes #37

## Test plan

- [x] `bun run build` compiles
- [x] `bun test` — all 11 tests pass
- [ ] Verify direct private IP URLs are still rejected
- [ ] Verify redirect to private IP is now rejected