### PR TITLE
Extract pure functions and add 30 unit tests

### DIFF
--- a/src/Markdownify.ts
+++ b/src/Markdownify.ts
@@ -4,9 +4,14 @@ import path from "path";
 import fs from "fs";
 import os from "os";
 import { fileURLToPath } from "url";
-import { URL } from "node:url";
-import is_ip_private from "private-ip";
-import { expandHome } from "./utils.js";
+import {
+  expandHome,
+  validateUrl,
+  isUnconvertedHtml,
+  inferExtensionFromUrl,
+  isMarkdownFile,
+  isWithinDirectory,
+} from "./utils.js";
 const execFileAsync = promisify(execFile);
 
 const __filename = fileURLToPath(import.meta.url);
@@ -42,9 +47,7 @@ export class Markdownify {
       throw new Error(`Error executing command: ${stderr}`);
     }
 
-    // Detect when markitdown returns unconverted HTML (e.g. JS-rendered SPAs)
-    const trimmed = stdout.trimStart();
-    if (trimmed.startsWith("<!DOCTYPE") || trimmed.startsWith("<html")) {
+    if (isUnconvertedHtml(stdout)) {
       throw new Error(
         "Conversion failed: the page returned raw HTML that could not be converted to Markdown. " +
           "This typically happens with JavaScript-rendered pages (SPAs) that require a browser to load content.",
@@ -71,25 +74,13 @@ export class Markdownify {
     return tempOutputPath;
   }
 
-  private static validateUrl(url: string): void {
-    const parsed = new URL(url);
-    if (!["http:", "https:"].includes(parsed.protocol)) {
-      throw new Error("Only http: and https: schemes are allowed.");
-    }
-    if (is_ip_private(parsed.hostname)) {
-      throw new Error(
-        `Fetching ${url} is potentially dangerous, aborting.`,
-      );
-    }
-  }
-
   private static async safeFetch(
     url: string,
     maxRedirects = 10,
   ): Promise<Response> {
     let currentUrl = url;
     for (let i = 0; i < maxRedirects; i++) {
-      this.validateUrl(currentUrl);
+      validateUrl(currentUrl);
       const response = await fetch(currentUrl, { redirect: "manual" });
       if (
         response.status >= 300 &&
@@ -107,10 +98,6 @@ export class Markdownify {
     throw new Error("Too many redirects");
   }
 
-  private static normalizePath(p: string): string {
-    return path.normalize(p);
-  }
-
   static async toMarkdown({
     filePath,
     url,
@@ -126,15 +113,7 @@ export class Markdownify {
 
       if (url) {
         const response = await this.safeFetch(url);
-
-        let extension: string | null = null;
-
-        if (url.endsWith(".pdf")) {
-          extension = "pdf";
-        } else {
-          // Default to .html so markitdown knows to convert HTML content
-          extension = "html";
-        }
+        const extension = inferExtensionFromUrl(url);
 
         const arrayBuffer = await response.arrayBuffer();
         const content = Buffer.from(arrayBuffer);
@@ -168,19 +147,15 @@ export class Markdownify {
   }: {
     filePath: string;
   }): Promise<MarkdownResult> {
-    // Check file type is *.md or *.markdown
-    const normPath = this.normalizePath(path.resolve(expandHome(filePath)));
-    const markdownExt = [".md", ".markdown"];
-    if (!markdownExt.includes(path.extname(normPath))) {
+    const resolvedPath = path.resolve(expandHome(filePath));
+    if (!isMarkdownFile(resolvedPath)) {
       throw new Error("Required file is not a Markdown file.");
     }
 
     if (process.env?.MD_SHARE_DIR) {
-      const allowedShareDir = this.normalizePath(
-        path.resolve(expandHome(process.env.MD_SHARE_DIR)),
-      );
-      if (!normPath.startsWith(allowedShareDir)) {
-        throw new Error(`Only files in ${allowedShareDir} are allowed.`);
+      const allowedShareDir = expandHome(process.env.MD_SHARE_DIR);
+      if (!isWithinDirectory(resolvedPath, allowedShareDir)) {
+        throw new Error(`Only files in ${path.normalize(path.resolve(allowedShareDir))} are allowed.`);
       }
     }
 

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -1,0 +1,163 @@
+import { expect, test, describe } from "bun:test";
+import {
+  expandHome,
+  validateUrl,
+  isUnconvertedHtml,
+  inferExtensionFromUrl,
+  isMarkdownFile,
+  isWithinDirectory,
+} from "./utils";
+import os from "os";
+import path from "path";
+
+describe("expandHome", () => {
+  test("expands ~/path to home directory", () => {
+    const result = expandHome("~/documents");
+    expect(result).toBe(path.join(os.homedir(), "documents"));
+  });
+
+  test("expands lone ~ to home directory", () => {
+    const result = expandHome("~");
+    expect(result).toBe(os.homedir());
+  });
+
+  test("does not expand paths without tilde", () => {
+    expect(expandHome("/usr/local")).toBe("/usr/local");
+  });
+
+  test("does not expand tilde in the middle of a path", () => {
+    expect(expandHome("/usr/~/local")).toBe("/usr/~/local");
+  });
+});
+
+describe("validateUrl", () => {
+  test("accepts http URLs", () => {
+    expect(() => validateUrl("http://example.com")).not.toThrow();
+  });
+
+  test("accepts https URLs", () => {
+    expect(() => validateUrl("https://example.com")).not.toThrow();
+  });
+
+  test("rejects ftp URLs", () => {
+    expect(() => validateUrl("ftp://example.com")).toThrow(
+      "Only http: and https: schemes are allowed.",
+    );
+  });
+
+  test("rejects file URLs", () => {
+    expect(() => validateUrl("file:///etc/passwd")).toThrow(
+      "Only http: and https: schemes are allowed.",
+    );
+  });
+
+  test("rejects private IP addresses", () => {
+    expect(() => validateUrl("http://192.168.1.1")).toThrow(
+      "potentially dangerous",
+    );
+  });
+
+  test("rejects localhost", () => {
+    expect(() => validateUrl("http://127.0.0.1")).toThrow(
+      "potentially dangerous",
+    );
+  });
+
+  test("rejects link-local addresses", () => {
+    expect(() => validateUrl("http://169.254.169.254")).toThrow(
+      "potentially dangerous",
+    );
+  });
+
+  test("throws on invalid URLs", () => {
+    expect(() => validateUrl("not-a-url")).toThrow();
+  });
+});
+
+describe("isUnconvertedHtml", () => {
+  test("detects DOCTYPE html", () => {
+    expect(isUnconvertedHtml("<!DOCTYPE html><html>...</html>")).toBe(true);
+  });
+
+  test("detects html tag", () => {
+    expect(isUnconvertedHtml("<html lang='en'>...</html>")).toBe(true);
+  });
+
+  test("detects html with leading whitespace", () => {
+    expect(isUnconvertedHtml("  \n<!DOCTYPE html>")).toBe(true);
+  });
+
+  test("returns false for markdown content", () => {
+    expect(isUnconvertedHtml("# Hello World\n\nSome text")).toBe(false);
+  });
+
+  test("returns false for empty string", () => {
+    expect(isUnconvertedHtml("")).toBe(false);
+  });
+
+  test("returns false for plain text", () => {
+    expect(isUnconvertedHtml("Just some plain text")).toBe(false);
+  });
+});
+
+describe("inferExtensionFromUrl", () => {
+  test("returns pdf for .pdf URLs", () => {
+    expect(inferExtensionFromUrl("https://example.com/doc.pdf")).toBe("pdf");
+  });
+
+  test("returns html for non-pdf URLs", () => {
+    expect(inferExtensionFromUrl("https://example.com/page")).toBe("html");
+  });
+
+  test("returns html for .html URLs", () => {
+    expect(inferExtensionFromUrl("https://example.com/page.html")).toBe("html");
+  });
+});
+
+describe("isMarkdownFile", () => {
+  test("accepts .md files", () => {
+    expect(isMarkdownFile("/path/to/file.md")).toBe(true);
+  });
+
+  test("accepts .markdown files", () => {
+    expect(isMarkdownFile("/path/to/file.markdown")).toBe(true);
+  });
+
+  test("rejects .txt files", () => {
+    expect(isMarkdownFile("/path/to/file.txt")).toBe(false);
+  });
+
+  test("rejects .pdf files", () => {
+    expect(isMarkdownFile("/path/to/file.pdf")).toBe(false);
+  });
+
+  test("rejects files without extension", () => {
+    expect(isMarkdownFile("/path/to/file")).toBe(false);
+  });
+});
+
+describe("isWithinDirectory", () => {
+  test("returns true for file inside directory", () => {
+    expect(isWithinDirectory("/home/user/docs/file.md", "/home/user/docs")).toBe(
+      true,
+    );
+  });
+
+  test("returns true for file in subdirectory", () => {
+    expect(
+      isWithinDirectory("/home/user/docs/sub/file.md", "/home/user/docs"),
+    ).toBe(true);
+  });
+
+  test("returns false for file outside directory", () => {
+    expect(isWithinDirectory("/home/user/other/file.md", "/home/user/docs")).toBe(
+      false,
+    );
+  });
+
+  test("returns false for path traversal attempt", () => {
+    expect(
+      isWithinDirectory("/home/user/docs/../other/file.md", "/home/user/docs"),
+    ).toBe(false);
+  });
+});

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,9 +1,46 @@
 import path from "path";
 import os from "os";
+import { URL } from "node:url";
+import is_ip_private from "private-ip";
 
 export function expandHome(filepath: string): string {
   if (filepath.startsWith("~/") || filepath === "~") {
     return path.join(os.homedir(), filepath.slice(1));
   }
   return filepath;
+}
+
+export function validateUrl(url: string): void {
+  const parsed = new URL(url);
+  if (!["http:", "https:"].includes(parsed.protocol)) {
+    throw new Error("Only http: and https: schemes are allowed.");
+  }
+  if (is_ip_private(parsed.hostname)) {
+    throw new Error(
+      `Fetching ${url} is potentially dangerous, aborting.`,
+    );
+  }
+}
+
+export function isUnconvertedHtml(output: string): boolean {
+  const trimmed = output.trimStart();
+  return trimmed.startsWith("<!DOCTYPE") || trimmed.startsWith("<html");
+}
+
+export function inferExtensionFromUrl(url: string): string {
+  if (url.endsWith(".pdf")) {
+    return "pdf";
+  }
+  return "html";
+}
+
+export function isMarkdownFile(filePath: string): boolean {
+  const markdownExt = [".md", ".markdown"];
+  return markdownExt.includes(path.extname(filePath));
+}
+
+export function isWithinDirectory(filePath: string, directory: string): boolean {
+  const normPath = path.normalize(path.resolve(filePath));
+  const normDir = path.normalize(path.resolve(directory));
+  return normPath.startsWith(normDir);
 }


### PR DESCRIPTION
## Summary

- Extract 6 pure functions from `Markdownify` class into `utils.ts`: `validateUrl`, `isUnconvertedHtml`, `inferExtensionFromUrl`, `isMarkdownFile`, `isWithinDirectory`, plus existing `expandHome`
- Add 30 new unit tests in `utils.test.ts` covering security validation, path traversal, HTML detection, and edge cases
- Test count: 11 → 41

Fixes #47

## Test plan

- [x] `bun run build` compiles
- [x] `bun test` — all 41 tests pass