### PR TITLE
Update dependencies and remove stale overrides

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,23 +5,15 @@
     "": {
       "name": "mcp-markdownify-server",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "1.27.1",
+        "@modelcontextprotocol/sdk": "^1.27.1",
         "private-ip": "^3.0.2",
         "zod": "^4.3.6",
       },
       "devDependencies": {
-        "@types/node": "^25.1.0",
-        "typescript": "^5.6.2",
+        "@types/node": "^25.3.5",
+        "typescript": "^5.9.3",
       },
     },
-  },
-  "overrides": {
-    "@hono/node-server": ">=1.19.10",
-    "ajv": ">=8.18.0",
-    "express-rate-limit": ">=8.2.2",
-    "hono": ">=4.12.4",
-    "minimatch": ">=3.1.4",
-    "qs": ">=6.14.2",
   },
   "packages": {
     "@chainsafe/is-ip": ["@chainsafe/is-ip@2.1.0", "", {}, "sha512-KIjt+6IfysQ4GCv66xihEitBjvhU/bixbbbFxdJ1sqCp4uJ0wuZiYBPhksZoy4lfaF0k9cwNzY5upEW/VWdw3w=="],

--- a/package.json
+++ b/package.json
@@ -22,20 +22,12 @@
     "test:watch": "bun test --watch"
   },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "1.27.1",
+    "@modelcontextprotocol/sdk": "^1.27.1",
     "private-ip": "^3.0.2",
     "zod": "^4.3.6"
   },
   "devDependencies": {
-    "@types/node": "^25.1.0",
-    "typescript": "^5.6.2"
-  },
-  "overrides": {
-    "hono": ">=4.12.4",
-    "@hono/node-server": ">=1.19.10",
-    "express-rate-limit": ">=8.2.2",
-    "ajv": ">=8.18.0",
-    "minimatch": ">=3.1.4",
-    "qs": ">=6.14.2"
+    "@types/node": "^25.3.5",
+    "typescript": "^5.9.3"
   }
 }


### PR DESCRIPTION
## Summary

- Update dependency version ranges to latest (all were already current)
- Remove stale `overrides` for packages no longer in the dependency tree (hono, express-rate-limit, ajv, minimatch, qs)
- No security vulnerabilities found

Fixes #40

## Test plan

- [x] `bun run build` compiles
- [x] `bun test` — all 41 tests pass