### PR TITLE
docs: add Fronteir AI hosted deployment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,10 @@ Markdownify is a Model Context Protocol (MCP) server that converts various file 
   - General web pages
 - Retrieve existing Markdown files
 
+## Hosted deployment
+
+A hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/zcaceres-markdownify-mcp).
+
 ## Getting Started
 
 1. Clone this repository


### PR DESCRIPTION
Love the project!

Adds a short note in the README that a hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/zcaceres-markdownify-mcp).