### PR TITLE
fix: use markitdown[pdf] instead of [all] to fix ARM Docker crash

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ COPY . .
 RUN rm .python-version
 
 # Install Python dependencies
-RUN python3 -m venv .venv && .venv/bin/pip install "markitdown[all]>=0.1.5"
+RUN python3 -m venv .venv && .venv/bin/pip install "markitdown[pdf]>=0.1.5"
 
 # Use a separate stage for building to save space
 FROM base AS builder


### PR DESCRIPTION
## Summary

- Replaces `markitdown[all]` with `markitdown[pdf]` in the Dockerfile
- `[all]` pulls in `SpeechRecognition`/`pydub` (requires ffmpeg) and `onnxruntime` extras that crash on Apple Silicon/ARM Docker containers
- `[pdf]` retains the PDF conversion support added in PR #92 without the unnecessary heavy dependencies

Fixes #95

## Test plan

- Build the Docker image on Apple Silicon: `docker build -t markdownify-test .`
- Run `webpage-to-markdown` via Docker on ARM and confirm no onnxruntime/ffmpeg errors
- Run `webpage-to-markdown` with a PDF URL to confirm PDF support still works