### PR TITLE
Make executable + allowlist paths overridable for Docker (closes #97)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+.git
+.venv
+node_modules
+dist
+markdownify
+*.log
+.DS_Store
+.env
+.env.*

--- a/README.md
+++ b/README.md
@@ -26,23 +26,23 @@ Markdownify is a Model Context Protocol (MCP) server that converts various file 
 1. Clone this repository
 2. Install dependencies:
    ```
-   pnpm install
+   bun install
    ```
 
-Note: this will also install `uv` and related Python depdencies.
+   The `preinstall` step creates a Python virtual environment at `.venv` and installs `markitdown[all]`.
 
 3. Build the project:
    ```
-   pnpm run build
+   bun run build
    ```
 4. Start the server:
    ```
-   pnpm start
+   bun start
    ```
 
 ## Development
 
-- Use `pnpm run dev` to start the TypeScript compiler in watch mode
+- Use `bun run dev` to start the TypeScript compiler in watch mode
 - Modify `src/server.ts` to customize server behavior
 - Add or modify tools in `src/tools.ts`
 
@@ -57,15 +57,38 @@ To integrate this server with a desktop app, add the following to your app's ser
       "command": "node",
       "args": [
         "{ABSOLUTE PATH TO FILE HERE}/dist/index.js"
-      ],
-      "env": {
-        // By default, the server will use the default install location of `uv`
-        "UV_PATH": "/path/to/uv"
-      }
+      ]
     }
   }
 }
 ```
+
+### Environment variables
+
+All paths default to sensible values; override only when the defaults don't fit your install layout.
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `MARKITDOWN_PATH` | `<project>/.venv/bin/markitdown`, then `markitdown` on `PATH` | Absolute path to the `markitdown` executable. Set this when you've installed markitdown system-wide (e.g. `pipx install "markitdown[pdf]"`) instead of using the bundled venv. |
+| `REPOMIX_PATH` | `<project>/node_modules/.bin/repomix`, then `repomix` on `PATH` | Absolute path to the `repomix` executable used by `git-repo-to-markdown`. |
+| `MD_ALLOWED_PATHS` | unset (unrestricted) | Path-delimiter-separated list (`:` on POSIX, `;` on Windows) of directories the server is allowed to read. When set, all file-input tools (`pdf-to-markdown`, `get-markdown-file`, etc.) reject paths outside these directories. |
+| `MD_SHARE_DIR` | unset | Deprecated alias for `MD_ALLOWED_PATHS` (single directory). Still honored for backward compatibility. |
+
+## Usage with Docker
+
+Build and run:
+```sh
+docker build -t markdownify-mcp .
+docker run --rm -i \
+  -v "$HOME/Documents:/data:ro" \
+  -e MD_ALLOWED_PATHS=/data \
+  markdownify-mcp
+```
+
+Notes for the Docker MCP catalog (`mcp/markdownify`):
+- Mount any host directories you want the server to read into the container, then pass the **container** paths to the tools (e.g. `/data/foo.pdf`, not `/Users/you/Documents/foo.pdf`).
+- Set `MD_ALLOWED_PATHS` to the colon-separated list of mounted directories so the server enforces a read boundary that matches the bind mount.
+- The published Docker image installs `markitdown[pdf]` only — audio transcription and image OCR (`audio-to-markdown`, `image-to-markdown`) require the `[all]` extras and will fail in the slim image. Use the local install (`bun install`) for the full feature set.
 
 ## Available Tools
 
@@ -79,8 +102,8 @@ To integrate this server with a desktop app, add the following to your app's ser
 - `xlsx-to-markdown`: Convert XLSX files to Markdown
 - `pptx-to-markdown`: Convert PPTX files to Markdown
 - `get-markdown-file`: Retrieve an existing Markdown file. File extension must end with: *.md, *.markdown.
-  
-  OPTIONAL: set `MD_SHARE_DIR` env var to restrict the directory from which files can be retrieved, e.g. `MD_SHARE_DIR=[SOME_PATH] pnpm run start` 
+
+  OPTIONAL: set `MD_ALLOWED_PATHS` to restrict every file-input tool to a list of directories, e.g. `MD_ALLOWED_PATHS=/data/in:/data/out bun start`.
 
 ## Contributing
 

--- a/scripts/docker-smoke-test.sh
+++ b/scripts/docker-smoke-test.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# End-to-end smoke test: build the image, mount sample-data, convert a PDF
+# over the MCP stdio transport, assert the output looks right.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+IMAGE="${IMAGE:-markdownify-mcp:smoke}"
+SAMPLE_DIR="$PWD/src/sample-data"
+EXPECTED_SUBSTRING="Test PDF content"
+
+if [[ ! -f "$SAMPLE_DIR/test.pdf" ]]; then
+  echo "missing $SAMPLE_DIR/test.pdf" >&2
+  exit 1
+fi
+
+echo "==> building $IMAGE"
+docker build -t "$IMAGE" . >/dev/null
+
+echo "==> running pdf-to-markdown via stdio"
+output=$({
+  printf '%s\n' \
+    '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"smoke","version":"0"}}}' \
+    '{"jsonrpc":"2.0","method":"notifications/initialized"}' \
+    '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"pdf-to-markdown","arguments":{"filepath":"/data/test.pdf"}}}'
+  sleep 5
+} | docker run --rm -i \
+    -v "$SAMPLE_DIR:/data:ro" \
+    -e MD_ALLOWED_PATHS=/data \
+    "$IMAGE")
+
+echo "$output"
+
+if ! grep -q '"id":2' <<<"$output"; then
+  echo "FAIL: no response to tools/call" >&2
+  exit 1
+fi
+
+if grep -q '"isError":true' <<<"$output"; then
+  echo "FAIL: tools/call returned isError:true" >&2
+  exit 1
+fi
+
+if ! grep -q "$EXPECTED_SUBSTRING" <<<"$output"; then
+  echo "FAIL: expected output to contain '$EXPECTED_SUBSTRING'" >&2
+  exit 1
+fi
+
+echo "==> PASS"

--- a/src/Markdownify.ts
+++ b/src/Markdownify.ts
@@ -11,7 +11,9 @@ import {
   isUnconvertedHtml,
   inferExtensionFromUrl,
   isMarkdownFile,
-  isWithinDirectory,
+  resolveMarkitdownPath,
+  resolveRepomixPath,
+  assertPathAllowed,
 } from "./utils.js";
 const execFileAsync = promisify(execFile);
 
@@ -28,26 +30,27 @@ export class Markdownify {
     filePath: string,
     projectRoot: string,
   ): Promise<string> {
-    const venvPath = path.join(projectRoot, ".venv");
-    const markitdownPath = path.join(
-      venvPath,
-      process.platform === "win32" ? "Scripts" : "bin",
-      `markitdown${process.platform === "win32" ? ".exe" : ""}`,
-    );
+    const markitdownPath = resolveMarkitdownPath(projectRoot);
 
-    if (!fs.existsSync(markitdownPath)) {
-      throw new Error(
-        `markitdown executable not found at ${markitdownPath}. ` +
-        `Ensure the Python virtual environment is set up by running: ` +
-        `python3 -m venv .venv && .venv/bin/pip install "markitdown>=0.1.5" ` +
-        `in the project root (${projectRoot}).`,
-      );
+    let stdout: string;
+    let stderr: string;
+    try {
+      // execFile resolves bare command names against PATH (POSIX execvp / Windows search)
+      ({ stdout, stderr } = await execFileAsync(markitdownPath, [filePath], {
+        maxBuffer: 50 * 1024 * 1024, // 50 MB
+      }));
+    } catch (e: unknown) {
+      const err = e as NodeJS.ErrnoException;
+      if (err?.code === "ENOENT") {
+        throw new Error(
+          `markitdown executable not found (looked up "${markitdownPath}"). ` +
+            `Set MARKITDOWN_PATH to its absolute location, install it on PATH (e.g. \`pipx install "markitdown[pdf]"\`), ` +
+            `or run setup in the project root (${projectRoot}): ` +
+            `python3 -m venv .venv && .venv/bin/pip install "markitdown[pdf]>=0.1.5".`,
+        );
+      }
+      throw e;
     }
-
-    // Use execFile to prevent command injection
-    const { stdout, stderr } = await execFileAsync(markitdownPath, [filePath], {
-      maxBuffer: 50 * 1024 * 1024, // 50 MB
-    });
 
     if (stderr) {
       throw new Error(`Error executing command: ${stderr}`);
@@ -127,7 +130,9 @@ export class Markdownify {
         inputPath = await this.saveToTempFile(content, extension);
         isTemporary = true;
       } else if (filePath) {
-        inputPath = filePath;
+        const expanded = expandHome(filePath);
+        assertPathAllowed(expanded);
+        inputPath = expanded;
       } else {
         throw new Error("Either filePath or url must be provided");
       }
@@ -159,17 +164,8 @@ export class Markdownify {
   }): Promise<MarkdownResult> {
     validateRepoUrl(repoUrl);
 
-    const repomixPath = path.join(
-      __dirname,
-      "..",
-      "node_modules",
-      ".bin",
-      "repomix",
-    );
-
-    if (!fs.existsSync(repomixPath)) {
-      throw new Error("repomix executable not found");
-    }
+    const projectRoot = path.resolve(__dirname, "..");
+    const repomixPath = resolveRepomixPath(projectRoot);
 
     const args = [
       "--remote",
@@ -188,9 +184,22 @@ export class Markdownify {
       args.push("--compress");
     }
 
-    const { stdout, stderr } = await execFileAsync(repomixPath, args, {
-      maxBuffer: 100 * 1024 * 1024, // 100 MB
-    });
+    let stdout: string;
+    let stderr: string;
+    try {
+      ({ stdout, stderr } = await execFileAsync(repomixPath, args, {
+        maxBuffer: 100 * 1024 * 1024, // 100 MB
+      }));
+    } catch (e: unknown) {
+      const err = e as NodeJS.ErrnoException;
+      if (err?.code === "ENOENT") {
+        throw new Error(
+          `repomix executable not found (looked up "${repomixPath}"). ` +
+            `Set REPOMIX_PATH or install it on PATH (\`bun add -g repomix\`).`,
+        );
+      }
+      throw e;
+    }
 
     if (!stdout) {
       throw new Error(
@@ -211,12 +220,7 @@ export class Markdownify {
       throw new Error("Required file is not a Markdown file.");
     }
 
-    if (process.env?.MD_SHARE_DIR) {
-      const allowedShareDir = expandHome(process.env.MD_SHARE_DIR);
-      if (!isWithinDirectory(resolvedPath, allowedShareDir)) {
-        throw new Error(`Only files in ${path.normalize(path.resolve(allowedShareDir))} are allowed.`);
-      }
-    }
+    assertPathAllowed(resolvedPath);
 
     if (!fs.existsSync(filePath)) {
       throw new Error("File does not exist");

--- a/src/Markdownify.ts
+++ b/src/Markdownify.ts
@@ -33,10 +33,11 @@ export class Markdownify {
     const markitdownPath = resolveMarkitdownPath(projectRoot);
 
     let stdout: string;
-    let stderr: string;
     try {
-      // execFile resolves bare command names against PATH (POSIX execvp / Windows search)
-      ({ stdout, stderr } = await execFileAsync(markitdownPath, [filePath], {
+      // execFile resolves bare command names against PATH (POSIX execvp / Windows search).
+      // Non-zero exit codes reject; stderr alone does not (markitdown emits non-fatal
+      // warnings from onnxruntime/pydub/etc. on a successful run).
+      ({ stdout } = await execFileAsync(markitdownPath, [filePath], {
         maxBuffer: 50 * 1024 * 1024, // 50 MB
       }));
     } catch (e: unknown) {
@@ -50,10 +51,6 @@ export class Markdownify {
         );
       }
       throw e;
-    }
-
-    if (stderr) {
-      throw new Error(`Error executing command: ${stderr}`);
     }
 
     if (isUnconvertedHtml(stdout)) {

--- a/src/server.ts
+++ b/src/server.ts
@@ -10,7 +10,6 @@ import { CallToolRequest } from "@modelcontextprotocol/sdk/types.js";
 const RequestPayloadSchema = z.object({
   filepath: z.string().optional(),
   url: z.string().optional(),
-  projectRoot: z.string().optional(),
   branch: z.string().optional(),
   compress: z.boolean().optional(),
 });
@@ -52,7 +51,6 @@ export function createServer() {
             }
             result = await Markdownify.toMarkdown({
               url: validatedArgs.url,
-              projectRoot: validatedArgs.projectRoot,
             });
             break;
 
@@ -67,7 +65,6 @@ export function createServer() {
             }
             result = await Markdownify.toMarkdown({
               filePath: validatedArgs.filepath,
-              projectRoot: validatedArgs.projectRoot,
             });
             break;
 

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -1,4 +1,4 @@
-import { expect, test, describe } from "bun:test";
+import { expect, test, describe, beforeEach, afterEach } from "bun:test";
 import {
   expandHome,
   validateUrl,
@@ -7,7 +7,12 @@ import {
   inferExtensionFromUrl,
   isMarkdownFile,
   isWithinDirectory,
+  resolveMarkitdownPath,
+  resolveRepomixPath,
+  getAllowedPaths,
+  assertPathAllowed,
 } from "./utils";
+import fs from "fs";
 import os from "os";
 import path from "path";
 
@@ -204,5 +209,146 @@ describe("validateRepoUrl", () => {
     expect(() => validateRepoUrl("ssh://git@github.com/owner/repo")).toThrow(
       "Only http: and https: repository URLs are allowed",
     );
+  });
+});
+
+describe("resolveMarkitdownPath", () => {
+  const savedEnv = process.env.MARKITDOWN_PATH;
+
+  afterEach(() => {
+    if (savedEnv === undefined) delete process.env.MARKITDOWN_PATH;
+    else process.env.MARKITDOWN_PATH = savedEnv;
+  });
+
+  test("honors MARKITDOWN_PATH env var", () => {
+    process.env.MARKITDOWN_PATH = "/opt/markitdown/bin/markitdown";
+    expect(resolveMarkitdownPath("/anywhere")).toBe(
+      "/opt/markitdown/bin/markitdown",
+    );
+  });
+
+  test("falls back to PATH lookup when no venv exists", () => {
+    delete process.env.MARKITDOWN_PATH;
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "mdfy-"));
+    try {
+      expect(resolveMarkitdownPath(tmp)).toBe("markitdown");
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  test("uses project venv when present", () => {
+    delete process.env.MARKITDOWN_PATH;
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "mdfy-"));
+    const isWin = process.platform === "win32";
+    const binDir = path.join(tmp, ".venv", isWin ? "Scripts" : "bin");
+    fs.mkdirSync(binDir, { recursive: true });
+    const expected = path.join(
+      binDir,
+      `markitdown${isWin ? ".exe" : ""}`,
+    );
+    fs.writeFileSync(expected, "");
+    try {
+      expect(resolveMarkitdownPath(tmp)).toBe(expected);
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("resolveRepomixPath", () => {
+  const savedEnv = process.env.REPOMIX_PATH;
+
+  afterEach(() => {
+    if (savedEnv === undefined) delete process.env.REPOMIX_PATH;
+    else process.env.REPOMIX_PATH = savedEnv;
+  });
+
+  test("honors REPOMIX_PATH env var", () => {
+    process.env.REPOMIX_PATH = "/opt/repomix/bin/repomix";
+    expect(resolveRepomixPath("/anywhere")).toBe("/opt/repomix/bin/repomix");
+  });
+
+  test("falls back to PATH lookup when bundled not present", () => {
+    delete process.env.REPOMIX_PATH;
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "mdfy-"));
+    try {
+      expect(resolveRepomixPath(tmp)).toBe("repomix");
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("getAllowedPaths / assertPathAllowed", () => {
+  const savedAllowed = process.env.MD_ALLOWED_PATHS;
+  const savedShare = process.env.MD_SHARE_DIR;
+
+  beforeEach(() => {
+    delete process.env.MD_ALLOWED_PATHS;
+    delete process.env.MD_SHARE_DIR;
+  });
+
+  afterEach(() => {
+    if (savedAllowed === undefined) delete process.env.MD_ALLOWED_PATHS;
+    else process.env.MD_ALLOWED_PATHS = savedAllowed;
+    if (savedShare === undefined) delete process.env.MD_SHARE_DIR;
+    else process.env.MD_SHARE_DIR = savedShare;
+  });
+
+  test("returns null when no env var set (unrestricted)", () => {
+    expect(getAllowedPaths()).toBeNull();
+  });
+
+  test("parses MD_ALLOWED_PATHS as delimiter-separated list", () => {
+    process.env.MD_ALLOWED_PATHS = ["/tmp/a", "/tmp/b"].join(path.delimiter);
+    const allowed = getAllowedPaths();
+    expect(allowed).toEqual(["/tmp/a", "/tmp/b"].map((p) => path.resolve(p)));
+  });
+
+  test("falls back to MD_SHARE_DIR for backward compatibility", () => {
+    process.env.MD_SHARE_DIR = "/tmp/legacy";
+    expect(getAllowedPaths()).toEqual([path.resolve("/tmp/legacy")]);
+  });
+
+  test("MD_ALLOWED_PATHS takes precedence over MD_SHARE_DIR", () => {
+    process.env.MD_ALLOWED_PATHS = "/tmp/new";
+    process.env.MD_SHARE_DIR = "/tmp/legacy";
+    expect(getAllowedPaths()).toEqual([path.resolve("/tmp/new")]);
+  });
+
+  test("expands ~ in allowed paths", () => {
+    process.env.MD_ALLOWED_PATHS = "~/docs";
+    expect(getAllowedPaths()).toEqual([path.join(os.homedir(), "docs")]);
+  });
+
+  test("ignores empty entries", () => {
+    process.env.MD_ALLOWED_PATHS = `/tmp/a${path.delimiter}${path.delimiter}/tmp/b`;
+    expect(getAllowedPaths()?.length).toBe(2);
+  });
+
+  test("assertPathAllowed is no-op when unrestricted", () => {
+    expect(() => assertPathAllowed("/etc/passwd")).not.toThrow();
+  });
+
+  test("assertPathAllowed permits files inside an allowed dir", () => {
+    process.env.MD_ALLOWED_PATHS = "/tmp/allowed";
+    expect(() =>
+      assertPathAllowed("/tmp/allowed/sub/file.pdf"),
+    ).not.toThrow();
+  });
+
+  test("assertPathAllowed rejects files outside allowed dirs", () => {
+    process.env.MD_ALLOWED_PATHS = "/tmp/allowed";
+    expect(() => assertPathAllowed("/etc/passwd")).toThrow(
+      "outside the allowed directories",
+    );
+  });
+
+  test("assertPathAllowed rejects path traversal escapes", () => {
+    process.env.MD_ALLOWED_PATHS = "/tmp/allowed";
+    expect(() =>
+      assertPathAllowed("/tmp/allowed/../etc/passwd"),
+    ).toThrow("outside the allowed directories");
   });
 });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,6 @@
 import path from "path";
 import os from "os";
+import fs from "fs";
 import { URL } from "node:url";
 import is_ip_private from "private-ip";
 import { isValidRemoteValue } from "repomix";
@@ -9,6 +10,50 @@ export function expandHome(filepath: string): string {
     return path.join(os.homedir(), filepath.slice(1));
   }
   return filepath;
+}
+
+export function resolveMarkitdownPath(projectRoot: string): string {
+  if (process.env.MARKITDOWN_PATH) return process.env.MARKITDOWN_PATH;
+  const isWin = process.platform === "win32";
+  const venvBin = path.join(
+    projectRoot,
+    ".venv",
+    isWin ? "Scripts" : "bin",
+    `markitdown${isWin ? ".exe" : ""}`,
+  );
+  if (fs.existsSync(venvBin)) return venvBin;
+  return "markitdown";
+}
+
+export function resolveRepomixPath(projectRoot: string): string {
+  if (process.env.REPOMIX_PATH) return process.env.REPOMIX_PATH;
+  const local = path.join(projectRoot, "node_modules", ".bin", "repomix");
+  if (fs.existsSync(local)) return local;
+  return "repomix";
+}
+
+export function getAllowedPaths(): string[] | null {
+  const raw = process.env.MD_ALLOWED_PATHS ?? process.env.MD_SHARE_DIR;
+  if (!raw) return null;
+  const dirs = raw
+    .split(path.delimiter)
+    .map((p) => p.trim())
+    .filter(Boolean)
+    .map((p) => path.normalize(path.resolve(expandHome(p))));
+  return dirs.length > 0 ? dirs : null;
+}
+
+export function assertPathAllowed(filePath: string): void {
+  const allowed = getAllowedPaths();
+  if (!allowed) return;
+  const resolved = path.normalize(path.resolve(expandHome(filePath)));
+  if (!allowed.some((dir) => isWithinDirectory(resolved, dir))) {
+    throw new Error(
+      `Path "${filePath}" is outside the allowed directories. ` +
+        `Set MD_ALLOWED_PATHS to a ${path.delimiter}-separated list that includes a parent directory ` +
+        `(currently allowed: ${allowed.join(path.delimiter)}).`,
+    );
+  }
 }
 
 export function validateUrl(url: string): void {


### PR DESCRIPTION
## Summary

Refs #97 — the manual setup the issue calls out is largely a **path-resolution** problem: this server hardcodes where `markitdown` lives, hardcodes where `repomix` lives, and only enforces a read-allowlist on one of ten tools. That makes Docker images (including the catalog image at `mcp/markdownify`) painful to build and use, and leaks an arbitrary-file-read primitive on host installs.

This PR makes every runtime path either correctly defaulted or explicitly env-overridable.

- **`MARKITDOWN_PATH`** (new env). Defaults to `<projectRoot>/.venv/bin/markitdown`, falls back to bare `markitdown` (which `execFile` resolves via `PATH`). Lets `pipx install "markitdown[pdf]"` or a system markitdown work without a project venv.
- **`REPOMIX_PATH`** (new env). Same shape, for `git-repo-to-markdown`.
- **`MD_ALLOWED_PATHS`** (new env, path-delimiter-separated). Enforced on **every** filepath-accepting tool, not just `get-markdown-file`. `MD_SHARE_DIR` kept as a single-dir backward-compat alias.
- **Removed `projectRoot` from the tool input schema.** It was client-controllable, so an MCP client could pass `projectRoot: "/etc"` and the server would happily exec `/etc/.venv/bin/markitdown` if it existed.
- **README**: replaced stale `UV_PATH` block with the new env table, added Docker volume-mount example aligned with the `markdownify.paths` field on https://hub.docker.com/mcp/server/markdownify/config.

The intended Docker UX:
```sh
docker run --rm -i \
  -v "$HOME/Documents:/data:ro" \
  -e MD_ALLOWED_PATHS=/data \
  markdownify-mcp
```
Tool calls then pass container paths (`/data/foo.pdf`); the server validates them against `MD_ALLOWED_PATHS` before handing off to markitdown.

## Test plan
- [x] `bun run build` — clean
- [x] `bun test ./src/utils.test.ts ./src/Markdownify.test.ts` — 79/79 pass
- [x] New unit tests cover: env override, venv fallback, PATH fallback, `MD_ALLOWED_PATHS` parsing (including `MD_SHARE_DIR` precedence and `~` expansion), allow/deny enforcement, path-traversal rejection.
- [ ] Smoke-test in Docker: `docker build -t markdownify-mcp . && docker run --rm -i -v "$PWD/src/sample-data:/data:ro" -e MD_ALLOWED_PATHS=/data markdownify-mcp` and call `pdf-to-markdown` with `/data/test.pdf`.
- [ ] Verify the published Docker MCP catalog image still works once the corresponding `server.yaml` maps `markdownify.paths` → `MD_ALLOWED_PATHS` and bind-mounts the same paths into the container.

## Follow-ups (not in this PR)
- Decide on the `[pdf]` vs `[all]` extras split in the Docker image (audio/image tools currently fail in the slim build — flagged in README).
- GitHub Action to publish multi-arch images to GHCR on tag.