### PR TITLE
fix: confine toMarkdown file inputs to MD_SHARE_DIR (CWE-73)

### DIFF
--- a/src/Markdownify.test.ts
+++ b/src/Markdownify.test.ts
@@ -103,6 +103,79 @@ test("Markdownify.toMarkdown throws error for non-existent file", async () => {
   ).rejects.toThrow();
 });
 
+test("Markdownify.toMarkdown rejects files outside MD_SHARE_DIR", async () => {
+  const originalShareDir = process.env.MD_SHARE_DIR;
+  const allowedDir = fs.mkdtempSync(path.join(tempDir, "md-share-"));
+  const outsideFile = path.join(sampleDataDir, "test.pdf");
+
+  process.env.MD_SHARE_DIR = allowedDir;
+
+  try {
+    await expect(
+      Markdownify.toMarkdown({ filePath: outsideFile }),
+    ).rejects.toThrow(`Only files in ${path.normalize(path.resolve(allowedDir))} are allowed.`);
+  } finally {
+    if (originalShareDir === undefined) {
+      delete process.env.MD_SHARE_DIR;
+    } else {
+      process.env.MD_SHARE_DIR = originalShareDir;
+    }
+    fs.rmSync(allowedDir, { recursive: true, force: true });
+  }
+});
+
+test("Markdownify.toMarkdown rejects sibling-directory prefix escapes", async () => {
+  const originalShareDir = process.env.MD_SHARE_DIR;
+  const parentDir = fs.mkdtempSync(path.join(tempDir, "md-share-parent-"));
+  const allowedDir = path.join(parentDir, "allowed");
+  const escapedDir = path.join(parentDir, "allowed-escape");
+  const escapedFile = path.join(escapedDir, "test.pdf");
+
+  fs.mkdirSync(allowedDir);
+  fs.mkdirSync(escapedDir);
+  fs.copyFileSync(path.join(sampleDataDir, "test.pdf"), escapedFile);
+  process.env.MD_SHARE_DIR = allowedDir;
+
+  try {
+    await expect(
+      Markdownify.toMarkdown({ filePath: escapedFile }),
+    ).rejects.toThrow(`Only files in ${path.normalize(path.resolve(allowedDir))} are allowed.`);
+  } finally {
+    if (originalShareDir === undefined) {
+      delete process.env.MD_SHARE_DIR;
+    } else {
+      process.env.MD_SHARE_DIR = originalShareDir;
+    }
+    fs.rmSync(parentDir, { recursive: true, force: true });
+  }
+});
+
+test("Markdownify.toMarkdown rejects symlink escapes from MD_SHARE_DIR", async () => {
+  const originalShareDir = process.env.MD_SHARE_DIR;
+  const allowedDir = fs.mkdtempSync(path.join(tempDir, "md-share-allowed-"));
+  const outsideDir = fs.mkdtempSync(path.join(tempDir, "md-share-outside-"));
+  const outsideFile = path.join(outsideDir, "test.pdf");
+  const symlinkPath = path.join(allowedDir, "linked.pdf");
+
+  fs.copyFileSync(path.join(sampleDataDir, "test.pdf"), outsideFile);
+  fs.symlinkSync(outsideFile, symlinkPath);
+  process.env.MD_SHARE_DIR = allowedDir;
+
+  try {
+    await expect(
+      Markdownify.toMarkdown({ filePath: symlinkPath }),
+    ).rejects.toThrow(`Only files in ${path.normalize(path.resolve(allowedDir))} are allowed.`);
+  } finally {
+    if (originalShareDir === undefined) {
+      delete process.env.MD_SHARE_DIR;
+    } else {
+      process.env.MD_SHARE_DIR = originalShareDir;
+    }
+    fs.rmSync(allowedDir, { recursive: true, force: true });
+    fs.rmSync(outsideDir, { recursive: true, force: true });
+  }
+});
+
 test("Markdownify.toMarkdown throws error when neither filePath nor url is provided", async () => {
   await expect(Markdownify.toMarkdown({})).rejects.toThrow(
     "Either filePath or url must be provided",

--- a/src/Markdownify.ts
+++ b/src/Markdownify.ts
@@ -63,6 +63,27 @@ export class Markdownify {
     return stdout;
   }
 
+  private static resolveSharedFilePath(filePath: string): string {
+    const resolvedPath = path.resolve(expandHome(filePath));
+
+    if (process.env?.MD_SHARE_DIR) {
+      const allowedShareDir = path.resolve(expandHome(process.env.MD_SHARE_DIR));
+
+      if (!fs.existsSync(resolvedPath)) {
+        throw new Error("File does not exist");
+      }
+
+      const realPath = fs.realpathSync(resolvedPath);
+      const realAllowedShareDir = fs.realpathSync(allowedShareDir);
+
+      if (!isWithinDirectory(realPath, realAllowedShareDir)) {
+        throw new Error(`Only files in ${path.normalize(allowedShareDir)} are allowed.`);
+      }
+    }
+
+    return resolvedPath;
+  }
+
   private static async saveToTempFile(
     content: string | Buffer,
     suggestedExtension?: string | null,
@@ -127,7 +148,7 @@ export class Markdownify {
         inputPath = await this.saveToTempFile(content, extension);
         isTemporary = true;
       } else if (filePath) {
-        inputPath = filePath;
+        inputPath = this.resolveSharedFilePath(filePath);
       } else {
         throw new Error("Either filePath or url must be provided");
       }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -59,7 +59,10 @@ export function isMarkdownFile(filePath: string): boolean {
 }
 
 export function isWithinDirectory(filePath: string, directory: string): boolean {
-  const normPath = path.normalize(path.resolve(filePath));
-  const normDir = path.normalize(path.resolve(directory));
-  return normPath.startsWith(normDir);
+  const relativePath = path.relative(
+    path.normalize(path.resolve(directory)),
+    path.normalize(path.resolve(filePath)),
+  );
+  return relativePath === "" ||
+    (!relativePath.startsWith("..") && !path.isAbsolute(relativePath));
 }


### PR DESCRIPTION
## Summary

This PR confines `Markdownify.toMarkdown` file inputs to an opt-in allow-listed directory and fixes a latent prefix-confusion bug in `isWithinDirectory`.

## Vulnerability

- **Class:** Path traversal / external control of file name (CWE-73)
- **Affected code:** `Markdownify.toMarkdown` in `src/Markdownify.ts`, reachable from the `pdf-to-markdown`, `image-to-markdown`, `audio-to-markdown`, `docx-to-markdown`, `xlsx-to-markdown`, and `pptx-to-markdown` MCP tools.
- **Data flow:** MCP tool args → `filePath` → passed unchecked as `inputPath` to the markitdown subprocess, which reads any file accessible to the server user.

In the MCP threat model the tool arguments are not necessarily chosen by the user — an indirect prompt injection in an attacker-controlled webpage or document can influence the assistant to invoke one of these tools with a sensitive path (e.g. `/etc/passwd`, `~/.ssh/id_rsa`, `~/.aws/credentials`) and stream the contents back through the model's response. There is no allow-list, no canonicalisation, and no symlink check before the path is handed to markitdown.

Separately, the existing `isWithinDirectory` helper used `normPath.startsWith(normDir)`, which suffers from the classic prefix-confusion bug: `/srv/share-evil` passes a `startsWith('/srv/share')` check. So even if a downstream caller relied on it for confinement, it would be bypassable.

## Fix

`src/Markdownify.ts`
- New `resolveSharedFilePath(filePath)`: when `MD_SHARE_DIR` is set in the environment, both the input path and the allowed directory are expanded, resolved, and `realpath`-ed (defeating symlink escapes), then containment is checked via `isWithinDirectory`. If `MD_SHARE_DIR` is not set, behaviour is unchanged — this is opt-in and fully backward-compatible.
- `toMarkdown` routes the `filePath` branch through this helper.

`src/utils.ts`
- `isWithinDirectory` rewritten to use `path.relative` and reject results that start with `..` or are absolute. This correctly handles the sibling-directory prefix case that `startsWith` got wrong.

`src/Markdownify.test.ts`
- Three regression tests: file outside `MD_SHARE_DIR` is rejected; a sibling directory whose name shares a prefix with the allowed dir (e.g. `allowed-escape` vs `allowed`) is rejected; a symlink inside the allowed dir pointing outside is rejected.

## Test results

The new tests pass alongside the existing suite. Each test sets `MD_SHARE_DIR` for its scope and restores the prior value in a `finally` block so it doesn't leak between tests.

## Why this is exploitable

Preconditions to exploit are low: the MCP server simply needs to be running and reachable by an LLM that can be influenced by attacker-controlled content (the standard indirect prompt injection model that MCP tools are subject to). No authentication bypass, no extra privilege — the file read happens with the server user's permissions, which in typical desktop installs includes the user's home directory, SSH keys, browser profiles, etc.

The fix mitigates this by giving operators a single env var to constrain what the tool can read. It does not break existing deployments (no `MD_SHARE_DIR` → no behaviour change), and where set it provides defence against both arbitrary-path traversal and symlink-based escape.

## Adversarial review

Before submitting, we tried to disprove this. The MCP server code does not validate `filePath` anywhere upstream of markitdown, and there is no framework-level sandbox — markitdown runs as a normal subprocess with the parent's filesystem access. We also confirmed the previous `isWithinDirectory` actually was prefix-bypassable with a small repro (`/foo/bar`.startsWith(`/foo/ba`) → true), so the helper rewrite is genuinely needed even outside this fix.

One honest caveat for the maintainer: because the protection is opt-in via `MD_SHARE_DIR`, deployments that don't set it remain exposed. It would be worth following up with a README note recommending operators set `MD_SHARE_DIR` (or defaulting it to a safe location like `~/Documents/markdownify-shared`) so the protection engages by default. Happy to send a docs PR on top if useful.

cc @lewiswigmore
