### PR TITLE
fix(url): pass URL string to markitdown so URL-aware routing fires

### DIFF
--- a/src/Markdownify.test.ts
+++ b/src/Markdownify.test.ts
@@ -255,6 +255,88 @@ test("Markdownify.fromRepo compress works on a multi-file repo", async () => {
   expect(result.text.length).toBeGreaterThan(500);
 }, 120_000);
 
+test("Markdownify.toMarkdown passes URL string to markitdown (not temp file) for URL-aware routing", async () => {
+  const testUrl = "https://www.youtube.com/watch?v=jNQXAC9IVRw";
+  const mockFetch = mock(() =>
+    Promise.resolve({
+      status: 200,
+      headers: { get: () => null },
+      arrayBuffer: () => Promise.resolve(new ArrayBuffer(0)),
+    }),
+  );
+  global.fetch = mockFetch as any;
+
+  const originalMarkitdown = Markdownify["_markitdown"];
+  let receivedArg: string | undefined;
+  Markdownify["_markitdown"] = mock(async (arg: string) => {
+    receivedArg = arg;
+    return "transcript";
+  });
+
+  try {
+    await Markdownify.toMarkdown({ url: testUrl });
+  } finally {
+    Markdownify["_markitdown"] = originalMarkitdown;
+  }
+
+  expect(receivedArg).toBe(testUrl);
+});
+
+test("Markdownify.toMarkdown follows redirects via safeFetch and passes the final URL to markitdown", async () => {
+  const startUrl = "https://example.com/start";
+  const finalUrl = "https://example.com/final";
+  const calls: string[] = [];
+  const mockFetch = mock((url: string) => {
+    calls.push(url);
+    if (url === startUrl) {
+      return Promise.resolve({
+        status: 302,
+        headers: { get: (h: string) => (h === "location" ? finalUrl : null) },
+      });
+    }
+    return Promise.resolve({
+      status: 200,
+      headers: { get: () => null },
+      arrayBuffer: () => Promise.resolve(new ArrayBuffer(0)),
+    });
+  });
+  global.fetch = mockFetch as any;
+
+  const originalMarkitdown = Markdownify["_markitdown"];
+  let receivedArg: string | undefined;
+  Markdownify["_markitdown"] = mock(async (arg: string) => {
+    receivedArg = arg;
+    return "ok";
+  });
+
+  try {
+    await Markdownify.toMarkdown({ url: startUrl });
+  } finally {
+    Markdownify["_markitdown"] = originalMarkitdown;
+  }
+
+  expect(calls).toEqual([startUrl, finalUrl]);
+  expect(receivedArg).toBe(finalUrl);
+});
+
+test("Markdownify.toMarkdown rejects URL whose redirect lands on a private IP (SSRF)", async () => {
+  const startUrl = "https://example.com/start";
+  const mockFetch = mock(() =>
+    Promise.resolve({
+      status: 302,
+      headers: {
+        get: (h: string) =>
+          h === "location" ? "http://169.254.169.254/" : null,
+      },
+    }),
+  );
+  global.fetch = mockFetch as any;
+
+  await expect(
+    Markdownify.toMarkdown({ url: startUrl }),
+  ).rejects.toThrow("potentially dangerous");
+});
+
 test("Markdownify.toMarkdown handles error from _markitdown method", async () => {
   const originalMarkitdown = Markdownify["_markitdown"];
   Markdownify["_markitdown"] = mock(() => {

--- a/src/Markdownify.ts
+++ b/src/Markdownify.ts
@@ -2,14 +2,12 @@ import { execFile } from "child_process";
 import { promisify } from "util";
 import path from "path";
 import fs from "fs";
-import os from "os";
 import { fileURLToPath } from "url";
 import {
   expandHome,
   validateUrl,
   validateRepoUrl,
   isUnconvertedHtml,
-  inferExtensionFromUrl,
   isMarkdownFile,
   resolveMarkitdownPath,
   resolveRepomixPath,
@@ -63,31 +61,19 @@ export class Markdownify {
     return stdout;
   }
 
-  private static async saveToTempFile(
-    content: string | Buffer,
-    suggestedExtension?: string | null,
-  ): Promise<string> {
-    let outputExtension = "md";
-    if (suggestedExtension != null) {
-      outputExtension = suggestedExtension;
-    }
-
-    const tempOutputPath = path.join(
-      os.tmpdir(),
-      `markdown_output_${Date.now()}.${outputExtension}`,
-    );
-    fs.writeFileSync(tempOutputPath, content);
-    return tempOutputPath;
-  }
-
-  private static async safeFetch(
+  // Walks the redirect chain validating each hop against SSRF rules, returning
+  // the final resolved URL. Hands no body back — markitdown does its own fetch
+  // on the resolved URL so its URL-aware routing (YouTube transcript API, Bing,
+  // generic webpage) can fire instead of seeing a downloaded blob.
+  private static async resolveValidatedUrl(
     url: string,
     maxRedirects = 10,
-  ): Promise<Response> {
+  ): Promise<string> {
     let currentUrl = url;
     for (let i = 0; i < maxRedirects; i++) {
       validateUrl(currentUrl);
       const response = await fetch(currentUrl, { redirect: "manual" });
+      response.body?.cancel().catch(() => {});
       if (
         response.status >= 300 &&
         response.status < 400 &&
@@ -99,7 +85,7 @@ export class Markdownify {
         ).toString();
         continue;
       }
-      return response;
+      return currentUrl;
     }
     throw new Error("Too many redirects");
   }
@@ -115,17 +101,14 @@ export class Markdownify {
   }): Promise<MarkdownResult> {
     try {
       let inputPath: string;
-      let isTemporary = false;
 
       if (url) {
-        const response = await this.safeFetch(url);
-        const extension = inferExtensionFromUrl(url);
-
-        const arrayBuffer = await response.arrayBuffer();
-        const content = Buffer.from(arrayBuffer);
-
-        inputPath = await this.saveToTempFile(content, extension);
-        isTemporary = true;
+        // Hand markitdown the URL string (post-redirect-validation) so its
+        // URL-aware routing — YouTube transcript API, Bing search, generic
+        // webpage — can fire. Downloading first and passing a temp .html file
+        // forces markitdown into its generic HTML→Markdown path and silently
+        // breaks all three tools (e.g. YouTube returns the page footer).
+        inputPath = await this.resolveValidatedUrl(url);
       } else if (filePath) {
         const expanded = expandHome(filePath);
         assertPathAllowed(expanded);
@@ -135,10 +118,6 @@ export class Markdownify {
       }
 
       const text = await this._markitdown(inputPath, projectRoot);
-
-      if (isTemporary) {
-        fs.unlinkSync(inputPath);
-      }
 
       return { text };
     } catch (e: unknown) {


### PR DESCRIPTION
URL-accepting tools (youtube-to-markdown, webpage-to-markdown, bing-search-to-markdown) download the URL to a temp .html file and hand that path to markitdown. markitdown's URL-aware converters — YouTube transcript API, Bing search, generic webpage — only fire when it receives a URL string, so every URL tool falls through to its generic HTML→Markdown path. Most visibly, youtube-to-markdown returns the YouTube page footer instead of the transcript.

Likely fixes #33 (webpage-to-markdown returns raw HTML blob) and #34 (youtube-to-markdown stdout maxBuffer exceeded — the YouTube watch page is ~1.2 MB of HTML; markitdown's URL routing skips the page entirely and calls youtube_transcript_api directly).

The fix walks the redirect chain via a small `resolveValidatedUrl` helper (same per-hop SSRF validation as `safeFetch` from #80) and passes the final resolved URL straight to markitdown. markitdown then does its own fetch and picks the right converter.

## What changed
- `src/Markdownify.ts`: `safeFetch` → `resolveValidatedUrl`, returns the final URL after walking redirects under SSRF validation. `toMarkdown` passes the URL string to markitdown instead of saving a temp file.
- `src/Markdownify.test.ts`: three new tests — URL string reaches markitdown, redirect chain resolves to the final URL, redirect to a private IP is still rejected.

## Verification
- `bun test` — 82/82 pass (79 existing + 3 new).
- `bun run build` — clean.
- End-to-end: `youtube-to-markdown` against `https://www.youtube.com/watch?v=jNQXAC9IVRw` now returns the real transcript ("All right, so here we are, in front of the elephants…") instead of the page footer.
- SSRF protection from #80 is preserved — every redirect hop is still validated before fetch; redirects to private IPs are still rejected (covered by a new test).