### PR TITLE
fix: close prefix-confusion and symlink bypasses in path allowlist

### DIFF
--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -166,6 +166,12 @@ describe("isWithinDirectory", () => {
       isWithinDirectory("/home/user/docs/../other/file.md", "/home/user/docs"),
     ).toBe(false);
   });
+
+  test("returns false for sibling directory with shared prefix", () => {
+    expect(
+      isWithinDirectory("/home/user/docs-evil/file.md", "/home/user/docs"),
+    ).toBe(false);
+  });
 });
 
 describe("validateRepoUrl", () => {
@@ -350,5 +356,57 @@ describe("getAllowedPaths / assertPathAllowed", () => {
     expect(() =>
       assertPathAllowed("/tmp/allowed/../etc/passwd"),
     ).toThrow("outside the allowed directories");
+  });
+
+  test("assertPathAllowed rejects sibling directory with shared prefix", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "mdfy-prefix-"));
+    try {
+      const allowed = path.join(tmp, "share");
+      const evilSibling = path.join(tmp, "share-evil");
+      fs.mkdirSync(allowed);
+      fs.mkdirSync(evilSibling);
+      const secret = path.join(evilSibling, "secret.txt");
+      fs.writeFileSync(secret, "top secret");
+      process.env.MD_ALLOWED_PATHS = allowed;
+      expect(() => assertPathAllowed(secret)).toThrow(
+        "outside the allowed directories",
+      );
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  test("assertPathAllowed rejects symlink inside allowed dir that escapes", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "mdfy-symlink-"));
+    try {
+      const allowed = path.join(tmp, "allowed");
+      const outside = path.join(tmp, "outside");
+      fs.mkdirSync(allowed);
+      fs.mkdirSync(outside);
+      const secret = path.join(outside, "secret.txt");
+      fs.writeFileSync(secret, "top secret");
+      const link = path.join(allowed, "link.txt");
+      fs.symlinkSync(secret, link);
+      process.env.MD_ALLOWED_PATHS = allowed;
+      expect(() => assertPathAllowed(link)).toThrow(
+        "outside the allowed directories",
+      );
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  test("assertPathAllowed permits regular file inside allowed dir after realpath", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "mdfy-happy-"));
+    try {
+      const allowed = path.join(tmp, "allowed");
+      fs.mkdirSync(allowed);
+      const file = path.join(allowed, "doc.pdf");
+      fs.writeFileSync(file, "%PDF-1.4");
+      process.env.MD_ALLOWED_PATHS = allowed;
+      expect(() => assertPathAllowed(file)).not.toThrow();
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
   });
 });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -43,15 +43,34 @@ export function getAllowedPaths(): string[] | null {
   return dirs.length > 0 ? dirs : null;
 }
 
+function realpathOrAncestor(p: string): string {
+  let current = path.resolve(p);
+  const suffix: string[] = [];
+  while (true) {
+    try {
+      const realCurrent = fs.realpathSync.native(current);
+      return suffix.length === 0
+        ? realCurrent
+        : path.join(realCurrent, ...suffix.slice().reverse());
+    } catch {
+      const parent = path.dirname(current);
+      if (parent === current) return path.resolve(p);
+      suffix.push(path.basename(current));
+      current = parent;
+    }
+  }
+}
+
 export function assertPathAllowed(filePath: string): void {
   const allowed = getAllowedPaths();
   if (!allowed) return;
-  const resolved = path.normalize(path.resolve(expandHome(filePath)));
-  if (!allowed.some((dir) => isWithinDirectory(resolved, dir))) {
+  const resolved = realpathOrAncestor(expandHome(filePath));
+  const allowedReal = allowed.map(realpathOrAncestor);
+  if (!allowedReal.some((dir) => isWithinDirectory(resolved, dir))) {
     throw new Error(
       `Path "${filePath}" is outside the allowed directories. ` +
         `Set MD_ALLOWED_PATHS to a ${path.delimiter}-separated list that includes a parent directory ` +
-        `(currently allowed: ${allowed.join(path.delimiter)}).`,
+        `(currently allowed: ${allowedReal.join(path.delimiter)}).`,
     );
   }
 }
@@ -104,7 +123,7 @@ export function isMarkdownFile(filePath: string): boolean {
 }
 
 export function isWithinDirectory(filePath: string, directory: string): boolean {
-  const normPath = path.normalize(path.resolve(filePath));
-  const normDir = path.normalize(path.resolve(directory));
-  return normPath.startsWith(normDir);
+  const rel = path.relative(path.resolve(directory), path.resolve(filePath));
+  if (rel === "") return true;
+  return !rel.startsWith("..") && !path.isAbsolute(rel);
 }


### PR DESCRIPTION
## Summary

Closes two real bypasses in the `MD_ALLOWED_PATHS` / `MD_SHARE_DIR` path allowlist:

1. **Prefix confusion in `isWithinDirectory`.** `src/utils.ts` used `normPath.startsWith(normDir)`, so `'/srv/share-evil/secret.txt'.startsWith('/srv/share')` returned `true`. A sibling directory whose name shares a prefix with the allowed dir bypassed the check.
2. **No symlink resolution in `assertPathAllowed`.** `path.resolve` + `path.normalize` don't follow symlinks, so an attacker who can write into the allowed directory (the intended use case for `MD_SHARE_DIR`) could plant a symlink to `~/.ssh/id_rsa`, `~/.aws/credentials`, etc., and exfiltrate via an LLM-triggered tool call.

Both bugs only affect operators who set `MD_ALLOWED_PATHS` / `MD_SHARE_DIR` — exactly the audience trusting the allowlist for safety. Default installs (no env var = no allowlist) are unaffected.

Context from the original report: #99. The PR's headline claim ("filePath is passed unchecked to markitdown") was already addressed by the existing `assertPathAllowed` call in `Markdownify.toMarkdown`, but the two sub-bugs above were left open. This PR closes them with the minimum surface area.

## Changes

**`src/utils.ts`**
- Rewrite `isWithinDirectory` to use `path.relative` and reject results that start with `..` or are absolute (the absolute case handles Windows cross-drive comparisons).
- Add `realpathOrAncestor` helper that resolves symlinks on the longest existing ancestor of a path and re-joins any non-existent suffix.
- `assertPathAllowed` now realpath-resolves both the input path and the allowed directories before the containment check.

**`src/utils.test.ts`**
- Sibling-prefix rejection test for `isWithinDirectory`.
- Three new `assertPathAllowed` tests: sibling-prefix rejection, symlink escape, and a realpath-aware happy path (also covers macOS `/tmp` → `/private/tmp`).

No new dependencies, no new env vars, no behavior change for users without the allowlist set.

## Test plan

- [x] `bun test src/utils.test.ts` — 95 pass, 0 fail
- [x] `bun run build` — clean compile
- [ ] Manual smoke against the MCP server with `MD_ALLOWED_PATHS` set:
  - File inside the dir → succeeds
  - Sibling-prefix path (`/tmp/allowed-evil/x`) → rejected
  - Symlink in the dir pointing to `/etc/hosts` → rejected