### PR TITLE
Fix path allowlist realpath checks

### DIFF
--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -166,6 +166,12 @@ describe("isWithinDirectory", () => {
       isWithinDirectory("/home/user/docs/../other/file.md", "/home/user/docs"),
     ).toBe(false);
   });
+
+  test("returns false for sibling directory with matching prefix", () => {
+    expect(
+      isWithinDirectory("/home/user/docs-archive/file.md", "/home/user/docs"),
+    ).toBe(false);
+  });
 });
 
 describe("validateRepoUrl", () => {
@@ -350,5 +356,51 @@ describe("getAllowedPaths / assertPathAllowed", () => {
     expect(() =>
       assertPathAllowed("/tmp/allowed/../etc/passwd"),
     ).toThrow("outside the allowed directories");
+  });
+
+  test("assertPathAllowed rejects sibling directories with matching prefix", () => {
+    process.env.MD_ALLOWED_PATHS = "/tmp/allowed";
+    expect(() =>
+      assertPathAllowed("/tmp/allowed-other/file.pdf"),
+    ).toThrow("outside the allowed directories");
+  });
+
+  test("assertPathAllowed rejects symlinks that escape allowed dirs", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "mdfy-"));
+    const allowed = path.join(tmp, "allowed");
+    const privateDir = path.join(tmp, "private");
+    fs.mkdirSync(allowed);
+    fs.mkdirSync(privateDir);
+    const target = path.join(privateDir, "secret.md");
+    const link = path.join(allowed, "report.md");
+    fs.writeFileSync(target, "# secret");
+    fs.symlinkSync(target, link);
+
+    try {
+      process.env.MD_ALLOWED_PATHS = allowed;
+      expect(() => assertPathAllowed(link)).toThrow(
+        "outside the allowed directories",
+      );
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  test("assertPathAllowed permits symlinks that stay within allowed dirs", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "mdfy-"));
+    const allowed = path.join(tmp, "allowed");
+    const docs = path.join(allowed, "docs");
+    fs.mkdirSync(docs, { recursive: true });
+    const target = path.join(docs, "report.md");
+    const link = path.join(allowed, "report.md");
+    fs.writeFileSync(target, "# report");
+    fs.symlinkSync(target, link);
+
+    try {
+      process.env.MD_ALLOWED_PATHS = allowed;
+      expect(() => assertPathAllowed(link)).not.toThrow();
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
   });
 });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -46,8 +46,9 @@ export function getAllowedPaths(): string[] | null {
 export function assertPathAllowed(filePath: string): void {
   const allowed = getAllowedPaths();
   if (!allowed) return;
-  const resolved = path.normalize(path.resolve(expandHome(filePath)));
-  if (!allowed.some((dir) => isWithinDirectory(resolved, dir))) {
+  const resolved = resolveForAccessCheck(filePath);
+  const allowedRoots = allowed.map((dir) => resolveForAccessCheck(dir));
+  if (!allowedRoots.some((dir) => isWithinDirectory(resolved, dir))) {
     throw new Error(
       `Path "${filePath}" is outside the allowed directories. ` +
         `Set MD_ALLOWED_PATHS to a ${path.delimiter}-separated list that includes a parent directory ` +
@@ -106,5 +107,18 @@ export function isMarkdownFile(filePath: string): boolean {
 export function isWithinDirectory(filePath: string, directory: string): boolean {
   const normPath = path.normalize(path.resolve(filePath));
   const normDir = path.normalize(path.resolve(directory));
-  return normPath.startsWith(normDir);
+  const relative = path.relative(normDir, normPath);
+  return (
+    relative === "" ||
+    (relative !== "" && !relative.startsWith("..") && !path.isAbsolute(relative))
+  );
+}
+
+function resolveForAccessCheck(filePath: string): string {
+  const expanded = expandHome(filePath);
+  try {
+    return path.normalize(fs.realpathSync.native(expanded));
+  } catch {
+    return path.normalize(path.resolve(expanded));
+  }
 }


### PR DESCRIPTION
## Summary
- canonicalize requested file paths and allowed roots with realpath before allowlist authorization
- replace prefix-based directory checks with path.relative boundary checks
- add regression coverage for symlink escapes and sibling path prefixes

Fixes #108

## Verification
- git diff --check
- node quick check for path.relative boundary behavior
- attempted bun test and focused bun test via npm exec, but both were killed by the local environment before completion
- attempted TypeScript compile via npm/npx temporary package execution, but this environment resolved no tsc binary