### PR TITLE
Fix predictable URL temp file paths

### DIFF
--- a/src/Markdownify.test.ts
+++ b/src/Markdownify.test.ts
@@ -82,6 +82,43 @@ test("Markdownify.toMarkdown converts URL content to Markdown", async () => {
   expect(result.text).toContain("# Example Domain");
 });
 
+test("Markdownify.toMarkdown stores fetched URL content in a private random temp path", async () => {
+  const originalMarkitdown = Markdownify["_markitdown"];
+  const testUrl = "https://example.com";
+  const html = "<h1>Private Temp Path</h1>";
+  let observedInputPath = "";
+
+  global.fetch = mock(() =>
+    Promise.resolve({
+      arrayBuffer: () =>
+        Promise.resolve(new TextEncoder().encode(html).buffer),
+    }),
+  ) as any;
+
+  Markdownify["_markitdown"] = mock((inputPath: string) => {
+    observedInputPath = inputPath;
+    expect(fs.readFileSync(inputPath, "utf8")).toBe(html);
+    return "# Private Temp Path";
+  }) as any;
+
+  try {
+    const result = await Markdownify.toMarkdown({ url: testUrl });
+    const tempDirName = path.basename(path.dirname(observedInputPath));
+
+    expect(result.text).toBe("# Private Temp Path");
+    expect(tempDirName.startsWith("markdownify-")).toBe(true);
+    expect(path.basename(observedInputPath)).toMatch(
+      /^markdown_output_[0-9a-f-]{36}\.html$/,
+    );
+    expect(observedInputPath).not.toMatch(
+      /markdown_output_\d{13}\.html$/,
+    );
+    expect(fs.existsSync(path.dirname(observedInputPath))).toBe(false);
+  } finally {
+    Markdownify["_markitdown"] = originalMarkitdown;
+  }
+});
+
 test("Markdownify.get retrieves existing Markdown file", async () => {
   const mdContent = "# Test Markdown\nThis is a test.";
   const tempFilePath = path.join(tempDir, "test_get.md");

--- a/src/Markdownify.ts
+++ b/src/Markdownify.ts
@@ -4,6 +4,7 @@ import path from "path";
 import fs from "fs";
 import os from "os";
 import { fileURLToPath } from "url";
+import { randomUUID } from "crypto";
 import {
   expandHome,
   validateUrl,
@@ -23,6 +24,11 @@ const __dirname = path.dirname(__filename);
 export type MarkdownResult = {
   path?: string;
   text: string;
+};
+
+type TemporaryFile = {
+  path: string;
+  cleanupDir: string;
 };
 
 export class Markdownify {
@@ -66,18 +72,25 @@ export class Markdownify {
   private static async saveToTempFile(
     content: string | Buffer,
     suggestedExtension?: string | null,
-  ): Promise<string> {
+  ): Promise<TemporaryFile> {
     let outputExtension = "md";
     if (suggestedExtension != null) {
       outputExtension = suggestedExtension;
     }
 
-    const tempOutputPath = path.join(
-      os.tmpdir(),
-      `markdown_output_${Date.now()}.${outputExtension}`,
+    const tempOutputDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), "markdownify-"),
     );
-    fs.writeFileSync(tempOutputPath, content);
-    return tempOutputPath;
+    const tempOutputPath = path.join(
+      tempOutputDir,
+      `markdown_output_${randomUUID()}.${outputExtension}`,
+    );
+    fs.writeFileSync(tempOutputPath, content, { flag: "wx" });
+    return { path: tempOutputPath, cleanupDir: tempOutputDir };
+  }
+
+  private static cleanupTempFile(tempFile: TemporaryFile): void {
+    fs.rmSync(tempFile.cleanupDir, { recursive: true, force: true });
   }
 
   private static async safeFetch(
@@ -113,9 +126,9 @@ export class Markdownify {
     url?: string;
     projectRoot?: string;
   }): Promise<MarkdownResult> {
+    let temporaryFile: TemporaryFile | null = null;
     try {
       let inputPath: string;
-      let isTemporary = false;
 
       if (url) {
         const response = await this.safeFetch(url);
@@ -124,8 +137,8 @@ export class Markdownify {
         const arrayBuffer = await response.arrayBuffer();
         const content = Buffer.from(arrayBuffer);
 
-        inputPath = await this.saveToTempFile(content, extension);
-        isTemporary = true;
+        temporaryFile = await this.saveToTempFile(content, extension);
+        inputPath = temporaryFile.path;
       } else if (filePath) {
         const expanded = expandHome(filePath);
         assertPathAllowed(expanded);
@@ -136,16 +149,16 @@ export class Markdownify {
 
       const text = await this._markitdown(inputPath, projectRoot);
 
-      if (isTemporary) {
-        fs.unlinkSync(inputPath);
-      }
-
       return { text };
     } catch (e: unknown) {
       if (e instanceof Error) {
         throw new Error(`Error processing to Markdown: ${e.message}`);
       } else {
         throw new Error("Error processing to Markdown: Unknown error occurred");
+      }
+    } finally {
+      if (temporaryFile) {
+        this.cleanupTempFile(temporaryFile);
       }
     }
   }


### PR DESCRIPTION
## Summary

- Replace timestamp-based URL temp artifact names with a private `mkdtemp` directory and a `randomUUID()` filename.
- Use exclusive file creation for fetched URL content.
- Clean up the private temp directory in a `finally` block after conversion.
- Add a regression test that verifies URL conversions use a random private temp path and clean it up.

Fixes zcaceres/markdownify-mcp#110

## Verification

- `node node_modules/typescript/bin/tsc --noEmit`
- `git diff --check`

Note: `bun` is not installed in this local environment, so I could not run `bun test`. An attempted `npm install` failed while creating a `.bin` symlink with `EIO`, but TypeScript was available afterward and the type check passed.
