### PR TITLE
Fix resolved URL destination validation

### DIFF
--- a/src/Markdownify.test.ts
+++ b/src/Markdownify.test.ts
@@ -66,7 +66,7 @@ test("Markdownify.toMarkdown converts image file to Markdown", async () => {
 });
 
 test("Markdownify.toMarkdown converts URL content to Markdown", async () => {
-  const testUrl = "https://example.com";
+  const testUrl = "https://93.184.216.34";
   const html = "<h1>Example Domain</h1>";
   const mockFetch = mock(() =>
     Promise.resolve({
@@ -80,6 +80,41 @@ test("Markdownify.toMarkdown converts URL content to Markdown", async () => {
 
   expect(result).toBeDefined();
   expect(result.text).toContain("# Example Domain");
+});
+
+test("Markdownify.toMarkdown rejects bracketed IPv6 loopback URLs before fetching", async () => {
+  const mockFetch = mock(() =>
+    Promise.resolve({
+      arrayBuffer: () =>
+        Promise.resolve(new TextEncoder().encode("").buffer),
+    }),
+  );
+  global.fetch = mockFetch as any;
+
+  await expect(
+    Markdownify.toMarkdown({ url: "http://[::1]:8080/metadata" }),
+  ).rejects.toThrow("potentially dangerous");
+  expect(mockFetch).toHaveBeenCalledTimes(0);
+});
+
+test("Markdownify.toMarkdown rejects redirects to loopback URLs", async () => {
+  const mockFetch = mock(() =>
+    Promise.resolve({
+      status: 302,
+      headers: {
+        get: (name: string) =>
+          name.toLowerCase() === "location"
+            ? "http://[::1]:8080/metadata"
+            : null,
+      },
+    }),
+  );
+  global.fetch = mockFetch as any;
+
+  await expect(
+    Markdownify.toMarkdown({ url: "https://93.184.216.34/start" }),
+  ).rejects.toThrow("potentially dangerous");
+  expect(mockFetch).toHaveBeenCalledTimes(1);
 });
 
 test("Markdownify.get retrieves existing Markdown file", async () => {

--- a/src/Markdownify.ts
+++ b/src/Markdownify.ts
@@ -6,7 +6,7 @@ import os from "os";
 import { fileURLToPath } from "url";
 import {
   expandHome,
-  validateUrl,
+  validateUrlDestination,
   validateRepoUrl,
   isUnconvertedHtml,
   inferExtensionFromUrl,
@@ -86,7 +86,7 @@ export class Markdownify {
   ): Promise<Response> {
     let currentUrl = url;
     for (let i = 0; i < maxRedirects; i++) {
-      validateUrl(currentUrl);
+      await validateUrlDestination(currentUrl);
       const response = await fetch(currentUrl, { redirect: "manual" });
       if (
         response.status >= 300 &&

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -2,6 +2,7 @@ import { expect, test, describe, beforeEach, afterEach } from "bun:test";
 import {
   expandHome,
   validateUrl,
+  validateUrlDestination,
   validateRepoUrl,
   isUnconvertedHtml,
   inferExtensionFromUrl,
@@ -75,8 +76,55 @@ describe("validateUrl", () => {
     );
   });
 
+  test("rejects bracketed IPv6 loopback addresses", () => {
+    expect(() => validateUrl("http://[::1]:8080")).toThrow(
+      "potentially dangerous",
+    );
+  });
+
+  test("rejects IPv4-mapped IPv6 loopback addresses", () => {
+    expect(() => validateUrl("http://[::ffff:7f00:1]")).toThrow(
+      "potentially dangerous",
+    );
+  });
+
   test("throws on invalid URLs", () => {
     expect(() => validateUrl("not-a-url")).toThrow();
+  });
+});
+
+describe("validateUrlDestination", () => {
+  test("accepts hostnames that resolve to public addresses", async () => {
+    await expect(
+      validateUrlDestination("https://public.example", async () => [
+        { address: "93.184.216.34", family: 4 },
+      ]),
+    ).resolves.toBeUndefined();
+  });
+
+  test("rejects hostnames that resolve to private addresses", async () => {
+    await expect(
+      validateUrlDestination("https://public.example", async () => [
+        { address: "10.0.0.10", family: 4 },
+      ]),
+    ).rejects.toThrow("potentially dangerous");
+  });
+
+  test("rejects hostnames that resolve to link-local addresses", async () => {
+    await expect(
+      validateUrlDestination("https://public.example", async () => [
+        { address: "169.254.169.254", family: 4 },
+      ]),
+    ).rejects.toThrow("potentially dangerous");
+  });
+
+  test("rejects hostnames when any resolved address is dangerous", async () => {
+    await expect(
+      validateUrlDestination("https://public.example", async () => [
+        { address: "93.184.216.34", family: 4 },
+        { address: "::1", family: 6 },
+      ]),
+    ).rejects.toThrow("potentially dangerous");
   });
 });
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -2,8 +2,79 @@ import path from "path";
 import os from "os";
 import fs from "fs";
 import { URL } from "node:url";
+import { lookup } from "node:dns/promises";
+import { isIP } from "node:net";
 import is_ip_private from "private-ip";
 import { isValidRemoteValue } from "repomix";
+
+type ResolvedAddress = {
+  address: string;
+  family: number;
+};
+
+type HostResolver = (hostname: string) => Promise<ResolvedAddress[]>;
+
+function normalizeHostname(hostname: string): string {
+  return hostname.replace(/^\[(.*)\]$/, "$1");
+}
+
+function ipv4FromMappedIpv6(address: string): string | null {
+  const prefix = "::ffff:";
+  const normalized = address.toLowerCase();
+  if (!normalized.startsWith(prefix)) return null;
+
+  const suffix = normalized.slice(prefix.length);
+  if (/^\d{1,3}(\.\d{1,3}){3}$/.test(suffix)) {
+    return suffix;
+  }
+
+  const parts = suffix.split(":");
+  if (parts.length !== 2) return null;
+
+  const high = Number.parseInt(parts[0], 16);
+  const low = Number.parseInt(parts[1], 16);
+  if (
+    !Number.isInteger(high) ||
+    !Number.isInteger(low) ||
+    high < 0 ||
+    high > 0xffff ||
+    low < 0 ||
+    low > 0xffff
+  ) {
+    return null;
+  }
+
+  return [
+    (high >> 8) & 0xff,
+    high & 0xff,
+    (low >> 8) & 0xff,
+    low & 0xff,
+  ].join(".");
+}
+
+function isPotentiallyDangerousIp(address: string): boolean {
+  const normalized = normalizeHostname(address);
+  if (!isIP(normalized)) return false;
+
+  const mappedIpv4 = ipv4FromMappedIpv6(normalized);
+  if (mappedIpv4) {
+    return is_ip_private(mappedIpv4) === true;
+  }
+
+  return is_ip_private(normalized) === true;
+}
+
+function assertSafeUrlDestination(url: string, address: string): void {
+  if (isPotentiallyDangerousIp(address)) {
+    throw new Error(
+      `Fetching ${url} is potentially dangerous, aborting.`,
+    );
+  }
+}
+
+async function resolveHostname(hostname: string): Promise<ResolvedAddress[]> {
+  return lookup(hostname, { all: true, verbatim: true });
+}
 
 export function expandHome(filepath: string): string {
   if (filepath.startsWith("~/") || filepath === "~") {
@@ -61,10 +132,24 @@ export function validateUrl(url: string): void {
   if (!["http:", "https:"].includes(parsed.protocol)) {
     throw new Error("Only http: and https: schemes are allowed.");
   }
-  if (is_ip_private(parsed.hostname)) {
-    throw new Error(
-      `Fetching ${url} is potentially dangerous, aborting.`,
-    );
+  assertSafeUrlDestination(url, parsed.hostname);
+}
+
+export async function validateUrlDestination(
+  url: string,
+  resolver: HostResolver = resolveHostname,
+): Promise<void> {
+  validateUrl(url);
+
+  const parsed = new URL(url);
+  const hostname = normalizeHostname(parsed.hostname);
+  if (isIP(hostname)) {
+    return;
+  }
+
+  const addresses = await resolver(hostname);
+  for (const { address } of addresses) {
+    assertSafeUrlDestination(url, address);
   }
 }
 


### PR DESCRIPTION
## Summary

- normalize bracketed IPv6 hostnames before private address checks
- resolve URL hostnames before fetching and reject any private, loopback, link-local, or reserved destination address
- apply the same destination validation to each manual redirect target

Fixes #112

## Testing

- node node_modules/typescript/bin/tsc --noEmit
- temporary compiled smoke test confirmed rejection of http://[::1], IPv4-mapped loopback, 127.0.0.1, and a hostname resolving to 10.0.0.10