### PR TITLE
fix(preinstall): resolve setup.bat from current directory on Windows

### DIFF
--- a/preinstall.js
+++ b/preinstall.js
@@ -1,7 +1,7 @@
 import { execSync } from 'child_process';
 
 if (process.platform === 'win32') {
-  execSync('setup.bat', { stdio: 'inherit' });
+  execSync('.\\setup.bat', { stdio: 'inherit' });
 } else {
   execSync('./setup.sh', { stdio: 'inherit' });
 }


### PR DESCRIPTION
## Problem

`bun install` (and `npm install`) fails on Windows during the `preinstall` step:

```
$ node preinstall.js
'setup.bat' is not recognized as an internal or external command,
operable program or batch file.
error: preinstall script from "mcp-markdownify-server" exited with 1
```

## Cause

`preinstall.js` calls `execSync('setup.bat')`. On Windows, `cmd.exe` (which Node's `execSync` uses on win32) does not search the current working directory for executables — only `%PATH%`. So an unqualified `setup.bat` fails to resolve even though it's right there in the project root. The POSIX branch already handles this correctly by prefixing with `./`.

## Fix

Mirror the POSIX form with the Windows equivalent prefix:

```diff
-  execSync('setup.bat', { stdio: 'inherit' });
+  execSync('.\setup.bat', { stdio: 'inherit' });
```

## Verification

Tested on Windows 11 + Node 22.18 + bun 1.3.14 against a fresh clone: `bun install` now completes successfully, creates `.venv\` and installs `markitdown[all]` as expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)