### PR TITLE
fix(build): make build script cross-platform on Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "setup.bat"
   ],
   "scripts": {
-    "build": "tsc && chmod +x dist/*.js",
+    "build": "tsc && node -e \"if (process.platform !== 'win32') require('child_process').execSync('chmod +x dist/*.js')\"",
     "dev": "tsc --watch",
     "preinstall": "node preinstall.js",
     "prepublishOnly": "bun run build",


### PR DESCRIPTION
## Summary
- `npm/bun run build` fails on Windows because the build script runs `chmod +x dist/*.js`, and `chmod` is not a recognized command on Windows. `tsc` succeeds first, so the only effect on Windows is a non-zero exit from a trailing no-op (NTFS doesn't use Unix executable bits anyway).
- Guard the chmod with `process.platform !== 'win32'`. macOS/Linux behavior is unchanged; Windows now exits 0.

## Change
```diff
-    "build": "tsc && chmod +x dist/*.js",
+    "build": "tsc && node -e \"if (process.platform !== 'win32') require('child_process').execSync('chmod +x dist/*.js')\"",
```

## Test plan
- [x] `bun run build` on Windows 11 (PowerShell) — exits 0, `dist/*.js` present
- [ ] `bun run build` on macOS/Linux — exits 0, `dist/*.js` retain `+x`

🤖 Generated with [Claude Code](https://claude.com/claude-code)