### PR TITLE
Add npm repository metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,10 @@
   "license": "MIT",
   "author": "@zcaceres (@zachcaceres | zach.dev)",
   "homepage": "https://github.com/zcaceres/markdownify-mcp",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/zcaceres/markdownify-mcp.git"
+  },
   "bugs": "https://github.com/zcaceres/markdownify-mcp/issues",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary

- add standard npm `repository` metadata pointing to this GitHub repo

## Why

The published `mcp-markdownify-server@1.1.0` package exposes `homepage` and `bugs`, while npm metadata currently omits `repository`. Adding the standard repository field helps npm users and package tooling trace the package back to source directly.

## Verification

- `node -e "const p=require('./package.json'); if(!p.repository?.url) process.exit(1); console.log(p.repository.url); console.log(p.bugs);"`
- `npm pack --dry-run --ignore-scripts`
- `git diff --check`

This is a package metadata-only change.