### PR TITLE
fix(url): route URL-keyed hosts to markitdown and upgrade the transcript API

### DIFF
--- a/setup.bat
+++ b/setup.bat
@@ -2,4 +2,9 @@ echo 'prepare Windows preinstall'
 echo 'Installing Python dependencies for OCR...'
 python -m venv .venv
 .venv\Scripts\pip install "markitdown[all]>=0.1.5"
+REM markitdown pins youtube-transcript-api~=1.0.0, and 1.0.x no longer parses YouTube's
+REM current transcript responses (it raises ParseError, and markitdown then silently
+REM emits the video page without a transcript). Upgrade it in a second step: installing
+REM both constraints at once fails with ResolutionImpossible.
+.venv\Scripts\pip install --upgrade "youtube-transcript-api>=1.2.4"
 echo 'Finished installing Python dependencies'

--- a/setup.sh
+++ b/setup.sh
@@ -4,4 +4,10 @@ echo 'prepare Unix preinstall'
 echo 'Installing Python dependencies for OCR...'
 python3 -m venv .venv
 .venv/bin/pip install "markitdown[all]>=0.1.5"
+# markitdown pins youtube-transcript-api~=1.0.0, and 1.0.x no longer parses YouTube's
+# current transcript responses (it raises ParseError, and markitdown then silently emits
+# the video page without a transcript). Upgrade it in a second step: installing both
+# constraints at once fails with ResolutionImpossible, and pip check reports no broken
+# requirements afterwards.
+.venv/bin/pip install --upgrade "youtube-transcript-api>=1.2.4"
 echo 'Finished installing Python dependencies'

--- a/src/Markdownify.test.ts
+++ b/src/Markdownify.test.ts
@@ -255,6 +255,115 @@ test("Markdownify.fromRepo compress works on a multi-file repo", async () => {
   expect(result.text.length).toBeGreaterThan(500);
 }, 120_000);
 
+test("Markdownify.toMarkdown passes a YouTube watch URL to markitdown instead of a temp file", async () => {
+  const testUrl = "https://www.youtube.com/watch?v=dQw4w9WgXcQ";
+  global.fetch = mock(() =>
+    Promise.resolve({
+      status: 200,
+      headers: { get: () => null },
+      body: null,
+      arrayBuffer: () => Promise.resolve(new ArrayBuffer(0)),
+    }),
+  ) as any;
+
+  const originalMarkitdown = Markdownify["_markitdown"];
+  let receivedArg: string | undefined;
+  Markdownify["_markitdown"] = mock(async (arg: string) => {
+    receivedArg = arg;
+    return "# YouTube\n\n### Transcript\nmocked";
+  });
+
+  try {
+    await Markdownify.toMarkdown({ url: testUrl });
+  } finally {
+    Markdownify["_markitdown"] = originalMarkitdown;
+  }
+
+  expect(receivedArg).toBe(testUrl);
+});
+
+test("Markdownify.toMarkdown resolves a youtu.be redirect before handing the URL to markitdown", async () => {
+  const shortUrl = "https://youtu.be/dQw4w9WgXcQ";
+  const resolvedUrl = "https://www.youtube.com/watch?v=dQw4w9WgXcQ";
+  global.fetch = mock((url: string) => {
+    if (url === shortUrl) {
+      return Promise.resolve({
+        status: 303,
+        headers: { get: (h: string) => (h === "location" ? resolvedUrl : null) },
+        body: null,
+      });
+    }
+    return Promise.resolve({
+      status: 200,
+      headers: { get: () => null },
+      body: null,
+      arrayBuffer: () => Promise.resolve(new ArrayBuffer(0)),
+    });
+  }) as any;
+
+  const originalMarkitdown = Markdownify["_markitdown"];
+  let receivedArg: string | undefined;
+  Markdownify["_markitdown"] = mock(async (arg: string) => {
+    receivedArg = arg;
+    return "ok";
+  });
+
+  try {
+    await Markdownify.toMarkdown({ url: shortUrl });
+  } finally {
+    Markdownify["_markitdown"] = originalMarkitdown;
+  }
+
+  expect(receivedArg).toBe(resolvedUrl);
+});
+
+test("Markdownify.toMarkdown still downloads non-allowlisted URLs to a temp file", async () => {
+  const testUrl = "https://example.com/page";
+  const html = "<h1>Example Domain</h1>";
+  global.fetch = mock(() =>
+    Promise.resolve({
+      status: 200,
+      headers: { get: () => null },
+      body: null,
+      arrayBuffer: () =>
+        Promise.resolve(new TextEncoder().encode(html).buffer),
+    }),
+  ) as any;
+
+  const originalMarkitdown = Markdownify["_markitdown"];
+  let receivedArg: string | undefined;
+  Markdownify["_markitdown"] = mock(async (arg: string) => {
+    receivedArg = arg;
+    return "# Example Domain";
+  });
+
+  try {
+    await Markdownify.toMarkdown({ url: testUrl });
+  } finally {
+    Markdownify["_markitdown"] = originalMarkitdown;
+  }
+
+  expect(receivedArg).not.toBe(testUrl);
+  expect(receivedArg).toContain("markdown_output_");
+});
+
+test("Markdownify.toMarkdown rejects a URL whose redirect lands on a private IP (SSRF)", async () => {
+  global.fetch = mock(() =>
+    Promise.resolve({
+      status: 302,
+      headers: {
+        get: (h: string) =>
+          h === "location" ? "http://169.254.169.254/latest/meta-data/" : null,
+      },
+      body: null,
+    }),
+  ) as any;
+
+  await expect(
+    Markdownify.toMarkdown({ url: "https://example.com/start" }),
+  ).rejects.toThrow("potentially dangerous");
+});
+
 test("Markdownify.toMarkdown handles error from _markitdown method", async () => {
   const originalMarkitdown = Markdownify["_markitdown"];
   Markdownify["_markitdown"] = mock(() => {

--- a/src/Markdownify.ts
+++ b/src/Markdownify.ts
@@ -10,6 +10,7 @@ import {
   validateRepoUrl,
   isUnconvertedHtml,
   inferExtensionFromUrl,
+  shouldPassUrlToMarkitdown,
   isMarkdownFile,
   resolveMarkitdownPath,
   resolveRepomixPath,
@@ -80,10 +81,15 @@ export class Markdownify {
     return tempOutputPath;
   }
 
+  // Walks the redirect chain, validating every hop against the SSRF rules, and returns
+  // the final response alongside the URL it actually came from. The resolved URL matters
+  // because markitdown's URL-keyed converters only recognize canonical forms: youtu.be
+  // and m.youtube.com links redirect to www.youtube.com/watch?v=..., so resolving before
+  // the allowlist check is what lets short links reach the YouTube converter.
   private static async safeFetch(
     url: string,
     maxRedirects = 10,
-  ): Promise<Response> {
+  ): Promise<{ response: Response; finalUrl: string }> {
     let currentUrl = url;
     for (let i = 0; i < maxRedirects; i++) {
       validateUrl(currentUrl);
@@ -93,13 +99,14 @@ export class Markdownify {
         response.status < 400 &&
         response.headers.get("location")
       ) {
+        response.body?.cancel().catch(() => {});
         currentUrl = new URL(
           response.headers.get("location")!,
           currentUrl,
         ).toString();
         continue;
       }
-      return response;
+      return { response, finalUrl: currentUrl };
     }
     throw new Error("Too many redirects");
   }
@@ -118,14 +125,23 @@ export class Markdownify {
       let isTemporary = false;
 
       if (url) {
-        const response = await this.safeFetch(url);
-        const extension = inferExtensionFromUrl(url);
+        const { response, finalUrl } = await this.safeFetch(url);
 
-        const arrayBuffer = await response.arrayBuffer();
-        const content = Buffer.from(arrayBuffer);
+        if (shouldPassUrlToMarkitdown(finalUrl)) {
+          // Hand the resolved URL to markitdown so its URL-keyed converter runs.
+          // Passing a downloaded temp file instead leaves stream_info.url unset and
+          // silently falls back to the generic HTML converter.
+          response.body?.cancel().catch(() => {});
+          inputPath = finalUrl;
+        } else {
+          const extension = inferExtensionFromUrl(url);
 
-        inputPath = await this.saveToTempFile(content, extension);
-        isTemporary = true;
+          const arrayBuffer = await response.arrayBuffer();
+          const content = Buffer.from(arrayBuffer);
+
+          inputPath = await this.saveToTempFile(content, extension);
+          isTemporary = true;
+        }
       } else if (filePath) {
         const expanded = expandHome(filePath);
         assertPathAllowed(expanded);

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -5,6 +5,7 @@ import {
   validateRepoUrl,
   isUnconvertedHtml,
   inferExtensionFromUrl,
+  shouldPassUrlToMarkitdown,
   isMarkdownFile,
   isWithinDirectory,
   resolveMarkitdownPath,
@@ -117,6 +118,87 @@ describe("inferExtensionFromUrl", () => {
 
   test("returns html for .html URLs", () => {
     expect(inferExtensionFromUrl("https://example.com/page.html")).toBe("html");
+  });
+});
+
+describe("shouldPassUrlToMarkitdown", () => {
+  test("accepts a canonical YouTube watch URL", () => {
+    expect(
+      shouldPassUrlToMarkitdown("https://www.youtube.com/watch?v=dQw4w9WgXcQ"),
+    ).toBe(true);
+  });
+
+  test("accepts a YouTube watch URL with extra query params", () => {
+    expect(
+      shouldPassUrlToMarkitdown(
+        "https://www.youtube.com/watch?v=dQw4w9WgXcQ&t=42s",
+      ),
+    ).toBe(true);
+  });
+
+  test("rejects a YouTube watch URL with no video id", () => {
+    expect(shouldPassUrlToMarkitdown("https://www.youtube.com/watch")).toBe(
+      false,
+    );
+  });
+
+  test("rejects non-watch YouTube paths", () => {
+    expect(
+      shouldPassUrlToMarkitdown("https://www.youtube.com/@somechannel"),
+    ).toBe(false);
+  });
+
+  // youtu.be and m.youtube.com reach the converter by having their redirects
+  // resolved first; markitdown itself only accepts the www.youtube.com form.
+  test("rejects unresolved youtu.be short links", () => {
+    expect(shouldPassUrlToMarkitdown("https://youtu.be/dQw4w9WgXcQ")).toBe(
+      false,
+    );
+  });
+
+  test("accepts a Bing SERP URL", () => {
+    expect(
+      shouldPassUrlToMarkitdown("https://www.bing.com/search?q=markitdown"),
+    ).toBe(true);
+  });
+
+  test("rejects a Bing URL that is not a search", () => {
+    expect(shouldPassUrlToMarkitdown("https://www.bing.com/images")).toBe(false);
+  });
+
+  // markitdown fetches with requests' default User-Agent, which Wikipedia 403s,
+  // so Wikipedia has to keep using this server's own fetch.
+  test("rejects Wikipedia despite markitdown having a converter for it", () => {
+    expect(
+      shouldPassUrlToMarkitdown("https://en.wikipedia.org/wiki/Markdown"),
+    ).toBe(false);
+  });
+
+  test("rejects arbitrary hosts", () => {
+    expect(shouldPassUrlToMarkitdown("https://example.com/page")).toBe(false);
+  });
+
+  test("rejects http YouTube URLs", () => {
+    expect(
+      shouldPassUrlToMarkitdown("http://www.youtube.com/watch?v=dQw4w9WgXcQ"),
+    ).toBe(false);
+  });
+
+  test("rejects lookalike hosts that merely contain an allowed domain", () => {
+    expect(
+      shouldPassUrlToMarkitdown(
+        "https://www.youtube.com.evil.test/watch?v=dQw4w9WgXcQ",
+      ),
+    ).toBe(false);
+    expect(
+      shouldPassUrlToMarkitdown(
+        "https://evil-www.youtube.com/watch?v=dQw4w9WgXcQ",
+      ),
+    ).toBe(false);
+  });
+
+  test("returns false for malformed URLs", () => {
+    expect(shouldPassUrlToMarkitdown("not a url")).toBe(false);
   });
 });
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -91,6 +91,41 @@ export function isUnconvertedHtml(output: string): boolean {
   return trimmed.startsWith("<!DOCTYPE") || trimmed.startsWith("<html");
 }
 
+// A few of markitdown's converters key off the URL itself rather than the bytes:
+// YouTubeConverter requires a URL starting "https://www.youtube.com/watch?" and
+// BingSerpConverter requires "https://www.bing.com/search?q=". Downloading those pages
+// first and handing markitdown a temp .html file leaves stream_info.url unset, so
+// accepts() returns false and the generic HTML converter runs instead. That is why
+// youtube-to-markdown returns the page footer and bing-search-to-markdown returns
+// localized SERP chrome. Those hosts have to reach markitdown as URL strings.
+//
+// Deliberately an allowlist rather than "pass every URL through": markitdown fetches
+// with requests' default User-Agent, which some hosts reject outright. en.wikipedia.org
+// and stackoverflow.com both answer 403 to markitdown while answering 200 to this
+// server's own fetch. Wikipedia is the sharp case, since markitdown ships a
+// WikipediaConverter that can never run on a live fetch, so routing every URL through
+// markitdown would trade working output for a hard 403 on those hosts.
+export function shouldPassUrlToMarkitdown(url: string): boolean {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return false;
+  }
+  if (parsed.protocol !== "https:") {
+    return false;
+  }
+
+  const host = parsed.hostname.toLowerCase();
+  if (host === "www.youtube.com") {
+    return parsed.pathname === "/watch" && parsed.searchParams.has("v");
+  }
+  if (host === "www.bing.com") {
+    return parsed.pathname === "/search" && parsed.searchParams.has("q");
+  }
+  return false;
+}
+
 export function inferExtensionFromUrl(url: string): string {
   if (url.endsWith(".pdf")) {
     return "pdf";


### PR DESCRIPTION
## The bug

`youtube-to-markdown` returns the YouTube page footer instead of a transcript:

```
[About](https://www.youtube.com/about/)[Press](...)[Copyright](...)
© 2026 Google LLC
```

There are **two independent causes**. Fixing either one alone leaves the tool broken, which I think is why this has been reported more than once.

### Cause 1: URL routing

All three URL tools download the page to a temp `.html` file and pass that path to markitdown. But `YouTubeConverter.accepts()` and `BingSerpConverter.accepts()` match on `stream_info.url`, which is unset for a local file:

```python
# markitdown/converters/_youtube_converter.py
if not url.startswith("https://www.youtube.com/watch?"):
    return False
```

So `accepts()` returns `False`, the generic HTML converter runs, and you get page chrome. Same for Bing, which returns localized SERP boilerplate instead of parsed results.

### Cause 2: markitdown's transcript pin

markitdown requires `youtube-transcript-api~=1.0.0`, and 1.0.x no longer parses YouTube's current transcript responses:

```
Attempt 1 failed: no element found: line 1, column 0
Attempt 2 failed: no element found: line 1, column 0
Attempt 3 failed: no element found: line 1, column 0
```

markitdown swallows that and emits the page without a transcript. **Verified on a clean venv built by the current `setup.sh`: fixing the routing alone still yields no transcript.** 1.2.4 parses correctly.

## The fix

**Routing (`src/utils.ts`, `src/Markdownify.ts`)** — an allowlist of hosts whose markitdown converters key off the URL, checked *after* redirect resolution. Everything else keeps the existing download path.

**Why an allowlist rather than passing every URL through** (which is what #100 and #106 do): markitdown fetches with `requests`' default User-Agent, and some hosts reject it while accepting this server's `fetch`.

| Host | markitdown fetches URL | current path (node fetches) |
|---|---|---|
| `en.wikipedia.org/wiki/Markdown` | **403 Forbidden** | 200, 63 KB |
| `stackoverflow.com/questions/tagged/python` | **403 Forbidden** | 200 |

Wikipedia is the sharp case: markitdown *ships* a `WikipediaConverter`, but it can never run on a live fetch, so a blanket passthrough trades working output for a hard 403. Confirmed by running both paths side by side.

`safeFetch` now returns the post-redirect URL alongside the response, so `youtu.be` and `m.youtube.com` links normalize into the `www.youtube.com/watch?v=` form the converter requires (`youtu.be/ID` → `303` → `www.youtube.com/watch?v=ID&feature=youtu.be`). Per-hop SSRF validation from #80 is unchanged; redirect and unused response bodies are now cancelled rather than left dangling.

Host matching is exact rather than suffix-based, so `www.youtube.com.evil.test` and `evil-www.youtube.com` do not match, and non-`https` is rejected.

**Dependency (`setup.sh`, `setup.bat`)** — upgrade `youtube-transcript-api` in a second step. It has to be two steps: installing both constraints at once fails with `ResolutionImpossible` against markitdown's `~=1.0.0`. Afterwards `pip check` reports `No broken requirements found`.

## Verification

`bun test` — **95/95 pass** (79 existing + 16 new). `bun run build` and `tsc --noEmit` clean.

End to end through the MCP protocol:

| Case | Result |
|---|---|
| `youtube-to-markdown` canonical URL | transcript, 11,972 chars |
| `youtube-to-markdown` `youtu.be` short link | transcript, 11,972 chars |
| `bing-search-to-markdown` | parsed results, was localized chrome |
| `webpage-to-markdown` Wikipedia | 63 KB, unchanged (no 403) |
| `webpage-to-markdown` StackOverflow | unchanged (no 403) |
| `webpage-to-markdown` example.com | unchanged |

New tests cover the allowlist boundaries (canonical/extra-params/no-video-id/non-watch paths, Bing search vs non-search, lookalike hosts, http, malformed URLs, Wikipedia staying off the list), that a YouTube URL reaches `_markitdown` as a URL, that a `youtu.be` redirect resolves first, that non-allowlisted URLs still go to a temp file, and that a redirect to a private IP is still rejected.

## Relation to #100 and #106

Both propose the routing half via a blanket passthrough. That fixes YouTube but regresses Wikipedia and StackOverflow to 403, and neither addresses cause 2, so `youtube-to-markdown` still returns no transcript on a freshly built venv. Happy to fold this into either if you'd prefer one of those as the base. Likely also fixes #33, and #34's 1.2 MB `maxBuffer` blowup goes away since the watch page is no longer piped through stdout.

## Notes

- `pyproject.toml`/`uv.lock` left alone deliberately: the lock is already stale (pins markitdown 0.1.5, no `[all]` extras, no transcript dep) and nothing in the repo invokes `uv`, so `setup.sh` is the real install path. Happy to add the override there too if you want the lock refreshed.
- YouTube geo-localizes title and description, so those fields may come back in the caller's region language while the transcript stays in the source language. Pre-existing markitdown behavior, not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
